### PR TITLE
feat: ERD v3.1 Entity 설정 및 Micrometer 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./src/main/resources/init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U fairticket"]
       interval: 10s

--- a/src/main/java/com/fairticket/domain/concert/entity/Concert.java
+++ b/src/main/java/com/fairticket/domain/concert/entity/Concert.java
@@ -1,0 +1,29 @@
+package com.fairticket.domain.concert.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("concerts")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Concert {
+
+    @Id
+    private Long id;
+
+    private String title;
+
+    private String artist;
+
+    private String venue;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/fairticket/domain/concert/entity/Schedule.java
+++ b/src/main/java/com/fairticket/domain/concert/entity/Schedule.java
@@ -1,0 +1,31 @@
+package com.fairticket.domain.concert.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("schedules")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Schedule {
+
+    @Id
+    private Long id;
+
+    private Long concertId;
+
+    private LocalDateTime dateTime;
+
+    private Integer totalSeats;
+
+    private LocalDateTime ticketOpenAt;
+
+    private String status;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/fairticket/domain/concert/entity/ScheduleGrade.java
+++ b/src/main/java/com/fairticket/domain/concert/entity/ScheduleGrade.java
@@ -1,0 +1,25 @@
+package com.fairticket.domain.concert.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("schedule_grades")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleGrade {
+
+    @Id
+    private Long id;
+
+    private Long scheduleId;
+
+    private String grade;
+
+    private Integer seatCount;
+
+    private Integer price;
+}

--- a/src/main/java/com/fairticket/domain/concert/entity/ScheduleStatus.java
+++ b/src/main/java/com/fairticket/domain/concert/entity/ScheduleStatus.java
@@ -1,0 +1,7 @@
+package com.fairticket.domain.concert.entity;
+
+public enum ScheduleStatus {
+    UPCOMING,
+    OPEN,
+    CLOSED
+}

--- a/src/main/java/com/fairticket/domain/payment/entity/Payment.java
+++ b/src/main/java/com/fairticket/domain/payment/entity/Payment.java
@@ -1,0 +1,41 @@
+package com.fairticket.domain.payment.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("payments")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Payment {
+
+    @Id
+    private Long id;
+
+    private Long reservationId;
+
+    private String merchantUid;
+
+    private String impUid;
+
+    private String pgTid;
+
+    private Integer amount;
+
+    private String method;
+
+    private String status;
+
+    private LocalDateTime expiresAt;
+
+    private LocalDateTime paidAt;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/fairticket/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/fairticket/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.fairticket.domain.payment.entity;
+
+public enum PaymentStatus {
+    PENDING,
+    COMPLETED,
+    FAILED,
+    REFUNDED
+}

--- a/src/main/java/com/fairticket/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/fairticket/domain/reservation/entity/Reservation.java
@@ -1,0 +1,39 @@
+package com.fairticket.domain.reservation.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("reservations")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Reservation {
+
+    @Id
+    private Long id;
+
+    private Long userId;
+
+    private Long scheduleId;
+
+    private String grade;
+
+    private String trackType;
+
+    private String status;
+
+    private Integer quantity;
+
+    private Boolean needsConfirm;
+
+    private LocalDateTime confirmDeadline;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/fairticket/domain/reservation/entity/ReservationSeat.java
+++ b/src/main/java/com/fairticket/domain/reservation/entity/ReservationSeat.java
@@ -1,0 +1,29 @@
+package com.fairticket.domain.reservation.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("reservation_seats")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationSeat {
+
+    @Id
+    private Long id;
+
+    private Long reservationId;
+
+    private Long seatId;
+
+    private String status;
+
+    private LocalDateTime assignedAt;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/fairticket/domain/reservation/entity/ReservationSeatStatus.java
+++ b/src/main/java/com/fairticket/domain/reservation/entity/ReservationSeatStatus.java
@@ -1,0 +1,7 @@
+package com.fairticket.domain.reservation.entity;
+
+public enum ReservationSeatStatus {
+    PENDING,
+    ASSIGNED,
+    CANCELLED
+}

--- a/src/main/java/com/fairticket/domain/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/fairticket/domain/reservation/entity/ReservationStatus.java
@@ -1,0 +1,10 @@
+package com.fairticket.domain.reservation.entity;
+
+public enum ReservationStatus {
+    PENDING,
+    PAID,
+    PAID_PENDING_SEAT,
+    ASSIGNED,
+    CANCELLED,
+    REFUNDED
+}

--- a/src/main/java/com/fairticket/domain/reservation/entity/TrackType.java
+++ b/src/main/java/com/fairticket/domain/reservation/entity/TrackType.java
@@ -1,0 +1,6 @@
+package com.fairticket.domain.reservation.entity;
+
+public enum TrackType {
+    CART,
+    SAME_DAY
+}

--- a/src/main/java/com/fairticket/domain/seat/entity/Seat.java
+++ b/src/main/java/com/fairticket/domain/seat/entity/Seat.java
@@ -1,0 +1,31 @@
+package com.fairticket.domain.seat.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("seats")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Seat {
+
+    @Id
+    private Long id;
+
+    private Long scheduleId;
+
+    private String grade;
+
+    private String seatNumber;
+
+    private Integer price;
+
+    private String status;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/fairticket/domain/seat/entity/SeatStatus.java
+++ b/src/main/java/com/fairticket/domain/seat/entity/SeatStatus.java
@@ -1,0 +1,7 @@
+package com.fairticket.domain.seat.entity;
+
+public enum SeatStatus {
+    AVAILABLE,
+    HELD,
+    SOLD
+}

--- a/src/main/java/com/fairticket/domain/user/entity/Role.java
+++ b/src/main/java/com/fairticket/domain/user/entity/Role.java
@@ -1,0 +1,6 @@
+package com.fairticket.domain.user.entity;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/fairticket/domain/user/entity/User.java
+++ b/src/main/java/com/fairticket/domain/user/entity/User.java
@@ -1,0 +1,33 @@
+package com.fairticket.domain.user.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("users")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    private String name;
+
+    private String phone;
+
+    private String role;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,0 +1,146 @@
+-- =============================================
+-- FairTicket ERD v3.1
+-- =============================================
+
+-- 사용자
+CREATE TABLE IF NOT EXISTS users (
+    id BIGSERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    phone VARCHAR(20),
+    role VARCHAR(20) NOT NULL DEFAULT 'USER',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 공연
+CREATE TABLE IF NOT EXISTS concerts (
+    id BIGSERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    artist VARCHAR(255),
+    venue VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 공연 회차
+CREATE TABLE IF NOT EXISTS schedules (
+    id BIGSERIAL PRIMARY KEY,
+    concert_id BIGINT NOT NULL REFERENCES concerts(id),
+    date_time TIMESTAMP NOT NULL,
+    total_seats INT NOT NULL,
+    ticket_open_at TIMESTAMP NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'UPCOMING',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 등급 설정
+CREATE TABLE IF NOT EXISTS schedule_grades (
+    id BIGSERIAL PRIMARY KEY,
+    schedule_id BIGINT NOT NULL REFERENCES schedules(id),
+    grade VARCHAR(10) NOT NULL,
+    seat_count INT NOT NULL,
+    price INT NOT NULL,
+    UNIQUE(schedule_id, grade)
+);
+
+-- 좌석
+CREATE TABLE IF NOT EXISTS seats (
+    id BIGSERIAL PRIMARY KEY,
+    schedule_id BIGINT NOT NULL REFERENCES schedules(id),
+    grade VARCHAR(10) NOT NULL,
+    seat_number VARCHAR(20) NOT NULL,
+    price INT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'AVAILABLE',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 예약
+CREATE TABLE IF NOT EXISTS reservations (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    schedule_id BIGINT NOT NULL REFERENCES schedules(id),
+    grade VARCHAR(10) NOT NULL,
+    track_type VARCHAR(20) NOT NULL,
+    status VARCHAR(30) NOT NULL DEFAULT 'PENDING',
+    quantity INT NOT NULL DEFAULT 1,
+    needs_confirm BOOLEAN DEFAULT FALSE,
+    confirm_deadline TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, schedule_id, track_type)
+);
+
+-- 예약-좌석
+CREATE TABLE IF NOT EXISTS reservation_seats (
+    id BIGSERIAL PRIMARY KEY,
+    reservation_id BIGINT NOT NULL REFERENCES reservations(id),
+    seat_id BIGINT REFERENCES seats(id),
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    assigned_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_reservation_seats_seat_id
+    ON reservation_seats(seat_id) WHERE seat_id IS NOT NULL;
+
+-- 결제
+CREATE TABLE IF NOT EXISTS payments (
+    id BIGSERIAL PRIMARY KEY,
+    reservation_id BIGINT NOT NULL REFERENCES reservations(id),
+    merchant_uid VARCHAR(100) UNIQUE NOT NULL,
+    imp_uid VARCHAR(100) UNIQUE,
+    pg_tid VARCHAR(100),
+    amount INT NOT NULL,
+    method VARCHAR(50),
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    expires_at TIMESTAMP,
+    paid_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- =============================================
+-- 인덱스
+-- =============================================
+CREATE INDEX IF NOT EXISTS idx_schedules_concert ON schedules(concert_id);
+CREATE INDEX IF NOT EXISTS idx_schedule_grades_schedule ON schedule_grades(schedule_id);
+CREATE INDEX IF NOT EXISTS idx_seats_schedule ON seats(schedule_id);
+CREATE INDEX IF NOT EXISTS idx_seats_status ON seats(status);
+CREATE INDEX IF NOT EXISTS idx_reservations_user ON reservations(user_id);
+CREATE INDEX IF NOT EXISTS idx_reservations_schedule ON reservations(schedule_id);
+CREATE INDEX IF NOT EXISTS idx_reservations_status ON reservations(status);
+CREATE INDEX IF NOT EXISTS idx_reservation_seats_reservation ON reservation_seats(reservation_id);
+CREATE INDEX IF NOT EXISTS idx_payments_reservation ON payments(reservation_id);
+CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status);
+
+-- =============================================
+-- 테스트 데이터
+-- =============================================
+
+-- 사용자
+INSERT INTO users (email, password, name, phone, role) VALUES
+    ('test1@test.com', 'password123', '테스트유저1', '010-1234-5678', 'USER'),
+    ('test2@test.com', 'password123', '테스트유저2', '010-2345-6789', 'USER'),
+    ('test3@test.com', 'password123', '테스트유저3', '010-3456-7890', 'USER'),
+    ('admin@test.com', 'admin123', '관리자', '010-0000-0000', 'ADMIN')
+ON CONFLICT (email) DO NOTHING;
+
+-- 공연
+INSERT INTO concerts (title, artist, venue) VALUES
+    ('2025 아이유 콘서트', '아이유', '잠실종합운동장')
+ON CONFLICT DO NOTHING;
+
+-- 공연 회차
+INSERT INTO schedules (concert_id, date_time, total_seats, ticket_open_at, status) VALUES
+    (1, '2025-03-15 19:00:00', 1000, '2025-02-15 20:00:00', 'UPCOMING')
+ON CONFLICT DO NOTHING;
+
+-- 등급 설정
+INSERT INTO schedule_grades (schedule_id, grade, seat_count, price) VALUES
+    (1, 'VIP', 100, 150000),
+    (1, 'R', 200, 120000),
+    (1, 'S', 300, 90000),
+    (1, 'A', 400, 60000)
+ON CONFLICT (schedule_id, grade) DO NOTHING;


### PR DESCRIPTION
## Summary
  - ERD v3.1 기준 Entity 클래스 및 Enum 정의
  - init.sql을 통한 테이블 자동 생성 및 테스트 데이터 삽입
  - Spring Micrometer Prometheus 의존성 추가

  ## Changes
  - **build.gradle**: `micrometer-registry-prometheus` 의존성 추가
  - **docker-compose.yml**: init.sql 볼륨 마운트 추가
  - **init.sql**: 테이블 8개, 인덱스 10개, 테스트 데이터
  - **Entity**: User, Concert, Schedule, ScheduleGrade, Seat, Reservation,
  ReservationSeat, Payment
  - **Enum**: Role, ScheduleStatus, SeatStatus, ReservationStatus, TrackType,
  ReservationSeatStatus, PaymentStatus

  ## ERD v3.1 변경사항
  - [추가] `ScheduleGrade` 테이블
  - [추가] `ReservationSeat` 중간 테이블
  - [추가] `Payment.merchant_uid`, `Payment.imp_uid`
  - [변경] `expired_at` → `expires_at`

  ## 검증
  
<img width="732" height="200" alt="스크린샷 2026-02-08 오후 5 40 08" src="https://github.com/user-attachments/assets/42112644-a1ae-463c-94f0-db316961ad73" />

<img width="1319" height="843" alt="스크린샷 2026-02-08 오후 5 50 15" src="https://github.com/user-attachments/assets/e7415f5a-7d84-4f7d-9717-c9505bc0d7e3" />

<img width="1495" height="878" alt="스크린샷 2026-02-08 오후 5 52 33" src="https://github.com/user-attachments/assets/be99e4db-111e-4370-a1d7-c4920fb212da" />

<img width="1326" height="847" alt="스크린샷 2026-02-08 오후 5 52 42" src="https://github.com/user-attachments/assets/8825c47f-8020-47e8-b66b-a561a3ba990d" />


  ## 로컬 반영 방법
  ```bash
  # 기존 볼륨 삭제 필수 (init.sql은 최초 생성 시만 실행)
  docker-compose down -v
  docker-compose up -d
```

  Closes #3 
