### PR TITLE
feat: 공통 예외 처리 및 Redis 키 유틸 구현

### DIFF
--- a/src/main/java/com/fairticket/global/exception/BusinessException.java
+++ b/src/main/java/com/fairticket/global/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.fairticket.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/fairticket/global/exception/ErrorCode.java
+++ b/src/main/java/com/fairticket/global/exception/ErrorCode.java
@@ -1,0 +1,53 @@
+package com.fairticket.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력입니다"),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 오류가 발생했습니다"),
+
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다"),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A003", "토큰이 만료되었습니다"),
+
+    // Queue
+    NOT_IN_QUEUE(HttpStatus.NOT_FOUND, "Q001", "대기열에 존재하지 않습니다"),
+    QUEUE_ENTRY_FAILED(HttpStatus.CONFLICT, "Q002", "대기열 진입에 실패했습니다"),
+    INVALID_QUEUE_TOKEN(HttpStatus.FORBIDDEN, "Q003", "유효하지 않은 입장 토큰입니다"),
+
+    // Reservation
+    ALREADY_PARTICIPATED(HttpStatus.CONFLICT, "R001", "이미 참여한 공연입니다"),
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "R002", "예약을 찾을 수 없습니다"),
+    RESERVATION_CANCELLED(HttpStatus.BAD_REQUEST, "R003", "취소된 예약입니다"),
+
+    // Seat
+    SEAT_ALREADY_TAKEN(HttpStatus.CONFLICT, "S001", "이미 선택된 좌석입니다"),
+    SEAT_HOLD_EXPIRED(HttpStatus.GONE, "S002", "좌석 홀드가 만료되었습니다"),
+    NO_AVAILABLE_SEATS(HttpStatus.NOT_FOUND, "S003", "잔여 좌석이 없습니다"),
+    SOLD_OUT(HttpStatus.GONE, "S004", "매진되었습니다"),
+
+    // Track
+    SAMEDAY_TRACK_CLOSED(HttpStatus.FORBIDDEN, "T001", "당일 트랙이 마감되었습니다"),
+    CART_TRACK_CLOSED(HttpStatus.FORBIDDEN, "T002", "장바구니 트랙이 마감되었습니다"),
+
+    // Payment
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "결제 정보를 찾을 수 없습니다"),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "P002", "결제 금액이 일치하지 않습니다"),
+    PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "P003", "이미 완료된 결제입니다"),
+    PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "P004", "결제 시간이 초과되었습니다"),
+    REFUND_FAILED(HttpStatus.BAD_REQUEST, "P005", "환불 처리에 실패했습니다"),
+
+    // Lock
+    LOCK_ACQUISITION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "L001", "락 획득에 실패했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/fairticket/global/exception/ErrorResponse.java
+++ b/src/main/java/com/fairticket/global/exception/ErrorResponse.java
@@ -1,0 +1,31 @@
+package com.fairticket.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/fairticket/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fairticket/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.fairticket.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.error("BusinessException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode, e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unexpected Exception: ", e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_ERROR.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_ERROR));
+    }
+}


### PR DESCRIPTION
 ## Summary
  - 전역 예외 처리 체계 구현 (ErrorCode → BusinessException →
  GlobalExceptionHandler)
  - Redis Key Design v3.1 기준 키 생성 유틸 구현

  ## Changes
  - **ErrorCode**: 에러 코드 26개 정의 (Common, Auth, Queue, Reservation, Seat,
  Track, Payment, Lock)
  - **BusinessException**: 커스텀 예외 클래스
  - **ErrorResponse**: 에러 응답 DTO (code, message, timestamp)
  - **GlobalExceptionHandler**: 전역 예외 핸들러 (`@RestControllerAdvice`)
  - **RedisKeyGenerator**: Redis 키 생성 메서드 11개 (v3.1 설계 기준)

  ## Redis Key Design v3.1
  | 타입 | 키 패턴 | 용도 |
  |------|---------|------|
  | SortedSet | `queue:{scheduleId}` | 대기열 순번 관리 |
  | Set | `seats:{scheduleId}:{grade}` | 등급별 잔여 좌석 풀 |
  | String | `remaining:{scheduleId}` | 당일 트랙 잔여 좌석 수 |
  | String | `sold:sameday:{scheduleId}` | 당일 트랙 판매 수 |
  | String+TTL | `hold:{scheduleId}:{grade}:{seatNo}` | 좌석 임시 홀드 (660초) |
  | Token+TTL | `token:{userId}:{scheduleId}` | 입장 토큰 (300초) |
  | Lock | `lock:assign:{scheduleId}:{grade}` | 좌석 배정 분산 락 |
  | String+TTL | `heartbeat:{scheduleId}:{userId}` | 대기열 이탈 감지 (30초) |
  | String | `active:{scheduleId}` | 동시 입장 인원 수 |
  | Set | `cart-paid:{scheduleId}` | 장바구니 결제 성공자 목록 |
  | String+TTL | `payment-timer:{reservationId}` | 미결제 자동 취소 타이머 |

  ## 검증
  
<img width="758" height="132" alt="스크린샷 2026-02-08 오후 10 02 43" src="https://github.com/user-attachments/assets/922651ce-80ef-4395-a586-26c08a8dce39" />


  Closes #5