### PR TITLE
feat: 대기열 시스템 구현

### DIFF
--- a/src/main/java/com/fairticket/domain/queue/controller/QueueController.java
+++ b/src/main/java/com/fairticket/domain/queue/controller/QueueController.java
@@ -1,0 +1,73 @@
+package com.fairticket.domain.queue.controller;
+
+import com.fairticket.domain.queue.dto.QueueEntryResponse;
+import com.fairticket.domain.queue.dto.QueueStatusResponse;
+import com.fairticket.domain.queue.service.QueueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/v1/queue")
+@RequiredArgsConstructor
+public class QueueController {
+
+    private final QueueService queueService;
+
+    /**
+     * 대기열 진입
+     * POST /api/v1/queue/{scheduleId}/enter
+     */
+    @PostMapping("/{scheduleId}/enter")
+    public Mono<ResponseEntity<QueueEntryResponse>> enterQueue(
+            @PathVariable Long scheduleId,
+            @RequestHeader("X-User-Id") Long userId) {
+        return queueService.enterQueue(scheduleId, userId)
+                .map(ResponseEntity::ok);
+    }
+
+    /**
+     * 대기열 상태 조회
+     * GET /api/v1/queue/{scheduleId}/status
+     */
+    @GetMapping("/{scheduleId}/status")
+    public Mono<ResponseEntity<QueueStatusResponse>> getStatus(
+            @PathVariable Long scheduleId,
+            @RequestHeader("X-User-Id") Long userId) {
+        return queueService.getQueueStatus(scheduleId, userId)
+                .map(status -> {
+                    if ("READY".equals(status.getStatus())) {
+                        return ResponseEntity.status(HttpStatus.TEMPORARY_REDIRECT)
+                                .header("Location", "/api/v1/reservation/" + scheduleId)
+                                .body(status);
+                    }
+                    return ResponseEntity.ok(status);
+                });
+    }
+
+    /**
+     * 대기열 취소
+     * DELETE /api/v1/queue/{scheduleId}/leave
+     */
+    @DeleteMapping("/{scheduleId}/leave")
+    public Mono<ResponseEntity<Void>> leaveQueue(
+            @PathVariable Long scheduleId,
+            @RequestHeader("X-User-Id") Long userId) {
+        return queueService.leaveQueue(scheduleId, userId)
+                .map(success -> ResponseEntity.noContent().<Void>build());
+    }
+
+    /**
+     * Heartbeat
+     * POST /api/v1/queue/{scheduleId}/heartbeat
+     */
+    @PostMapping("/{scheduleId}/heartbeat")
+    public Mono<ResponseEntity<Void>> heartbeat(
+            @PathVariable Long scheduleId,
+            @RequestHeader("X-User-Id") Long userId) {
+        return queueService.heartbeat(scheduleId, userId)
+                .map(success -> ResponseEntity.ok().<Void>build());
+    }
+}

--- a/src/main/java/com/fairticket/domain/queue/dto/QueueEntryRequest.java
+++ b/src/main/java/com/fairticket/domain/queue/dto/QueueEntryRequest.java
@@ -1,0 +1,10 @@
+package com.fairticket.domain.queue.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class QueueEntryRequest {
+    private Long scheduleId;
+}

--- a/src/main/java/com/fairticket/domain/queue/dto/QueueEntryResponse.java
+++ b/src/main/java/com/fairticket/domain/queue/dto/QueueEntryResponse.java
@@ -1,0 +1,14 @@
+package com.fairticket.domain.queue.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QueueEntryResponse {
+    private Long scheduleId;
+    private Long userId;
+    private Long position;
+    private Integer estimatedWaitMinutes;
+    private String message;
+}

--- a/src/main/java/com/fairticket/domain/queue/dto/QueueStatusResponse.java
+++ b/src/main/java/com/fairticket/domain/queue/dto/QueueStatusResponse.java
@@ -1,0 +1,15 @@
+package com.fairticket.domain.queue.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QueueStatusResponse {
+    private Long position;
+    private String status;
+    private String token;
+    private Integer estimatedWaitMinutes;
+    private Long aheadCount;
+    private String message;
+}

--- a/src/main/java/com/fairticket/domain/queue/service/QueueScheduler.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueScheduler.java
@@ -1,0 +1,88 @@
+package com.fairticket.domain.queue.service;
+
+import com.fairticket.global.util.RedisKeyGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueScheduler {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final QueueTokenService queueTokenService;
+
+    private static final int BATCH_SIZE = 100;
+    private static final int MAX_ACTIVE_USERS = 500;
+
+    /**
+     * 배치 입장 처리 (5초마다)
+     * active 인원이 MAX_ACTIVE_USERS 미만이면 대기열에서 다음 배치 입장
+     */
+    @Scheduled(fixedDelay = 5000)
+    public void processBatchEntry() {
+        redisTemplate.keys("queue:*")
+                .flatMap(queueKey -> {
+                    String scheduleId = queueKey.split(":")[1];
+                    String activeKey = RedisKeyGenerator.active(Long.parseLong(scheduleId));
+
+                    return redisTemplate.opsForValue().get(activeKey)
+                            .defaultIfEmpty("0")
+                            .map(Integer::parseInt)
+                            .flatMapMany(activeCount -> {
+                                if (activeCount >= MAX_ACTIVE_USERS) {
+                                    return Flux.empty();
+                                }
+
+                                int allowCount = Math.min(BATCH_SIZE, MAX_ACTIVE_USERS - activeCount);
+
+                                return redisTemplate.opsForZSet()
+                                        .range(queueKey, org.springframework.data.domain.Range.closed(0L, (long) allowCount - 1))
+                                        .flatMap(userId -> {
+                                            Long uid = Long.parseLong(userId);
+                                            Long sid = Long.parseLong(scheduleId);
+
+                                            return queueTokenService.issueToken(uid, sid)
+                                                    .then(redisTemplate.opsForZSet().remove(queueKey, userId))
+                                                    .then(redisTemplate.opsForValue().increment(activeKey))
+                                                    .doOnSuccess(v -> log.info("배치 입장: userId={}, scheduleId={}", uid, sid));
+                                        });
+                            });
+                })
+                .subscribe();
+    }
+
+    /**
+     * Heartbeat 미갱신 사용자 대기열 제거 (10초마다)
+     */
+    @Scheduled(fixedDelay = 10000)
+    public void cleanupInactiveUsers() {
+        redisTemplate.keys("queue:*")
+                .flatMap(queueKey -> {
+                    String scheduleId = queueKey.split(":")[1];
+                    Long sid = Long.parseLong(scheduleId);
+
+                    return redisTemplate.opsForZSet()
+                            .range(queueKey, org.springframework.data.domain.Range.closed(0L, -1L))
+                            .flatMap(userId -> {
+                                String heartbeatKey = RedisKeyGenerator.heartbeat(sid, Long.parseLong(userId));
+
+                                return redisTemplate.hasKey(heartbeatKey)
+                                        .flatMap(hasHeartbeat -> {
+                                            if (!hasHeartbeat) {
+                                                return redisTemplate.opsForZSet()
+                                                        .remove(queueKey, userId)
+                                                        .doOnSuccess(v -> log.info("비활성 사용자 제거: userId={}, scheduleId={}",
+                                                                userId, scheduleId));
+                                            }
+                                            return reactor.core.publisher.Mono.empty();
+                                        });
+                            });
+                })
+                .subscribe();
+    }
+}

--- a/src/main/java/com/fairticket/domain/queue/service/QueueService.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueService.java
@@ -1,0 +1,154 @@
+package com.fairticket.domain.queue.service;
+
+import com.fairticket.domain.queue.dto.QueueEntryResponse;
+import com.fairticket.domain.queue.dto.QueueStatusResponse;
+import com.fairticket.global.exception.BusinessException;
+import com.fairticket.global.exception.ErrorCode;
+import com.fairticket.global.util.RedisKeyGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final QueueTokenService queueTokenService;
+
+    private static final int BATCH_SIZE = 100;
+    private static final Duration HEARTBEAT_TTL = Duration.ofSeconds(30);
+
+    /**
+     * 대기열 진입
+     */
+    public Mono<QueueEntryResponse> enterQueue(Long scheduleId, Long userId) {
+        String queueKey = RedisKeyGenerator.queue(scheduleId);
+        String tokenKey = RedisKeyGenerator.queueToken(userId, scheduleId);
+
+        // 1. 토큰 존재 여부 체크 (이미 입장 처리된 유저)
+        return redisTemplate.hasKey(tokenKey)
+                .flatMap(hasToken -> {
+                    if (hasToken) {
+                        return Mono.<QueueEntryResponse>just(QueueEntryResponse.builder()
+                                .scheduleId(scheduleId)
+                                .userId(userId)
+                                .position(0L)
+                                .estimatedWaitMinutes(0)
+                                .message("이미 입장 토큰이 발급되었습니다")
+                                .build());
+                    }
+
+                    // 2. 대기열 존재 여부 체크 (이미 대기 중인 유저)
+                    return redisTemplate.opsForZSet()
+                            .rank(queueKey, userId.toString())
+                            .flatMap(existingRank -> {
+                                long position = existingRank + 1;
+                                return Mono.<QueueEntryResponse>just(QueueEntryResponse.builder()
+                                        .scheduleId(scheduleId)
+                                        .userId(userId)
+                                        .position(position)
+                                        .estimatedWaitMinutes(calculateEstimatedWait(position))
+                                        .message(String.format("이미 대기 중입니다. 현재 %d번째입니다", position))
+                                        .build());
+                            })
+                            .switchIfEmpty(
+                                    // 3. 신규 진입
+                                    Mono.defer(() -> {
+                                        double score = System.currentTimeMillis();
+                                        String heartbeatKey = RedisKeyGenerator.heartbeat(scheduleId, userId);
+
+                                        return redisTemplate.opsForZSet()
+                                                .add(queueKey, userId.toString(), score)
+                                                .then(redisTemplate.opsForValue().set(heartbeatKey, "alive", HEARTBEAT_TTL))
+                                                .then(getPosition(scheduleId, userId))
+                                                .map(position -> QueueEntryResponse.builder()
+                                                        .scheduleId(scheduleId)
+                                                        .userId(userId)
+                                                        .position(position)
+                                                        .estimatedWaitMinutes(calculateEstimatedWait(position))
+                                                        .message(String.format("%d번째로 대기 중입니다", position))
+                                                        .build());
+                                    })
+                            );
+                })
+                .doOnSuccess(response -> log.info("대기열 진입: userId={}, scheduleId={}, position={}",
+                        userId, scheduleId, response.getPosition()));
+    }
+
+    /**
+     * 대기열 상태 조회 (Polling용)
+     */
+    public Mono<QueueStatusResponse> getQueueStatus(Long scheduleId, Long userId) {
+        String queueKey = RedisKeyGenerator.queue(scheduleId);
+
+        return redisTemplate.opsForZSet()
+                .rank(queueKey, userId.toString())
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.NOT_IN_QUEUE)))
+                .map(rank -> rank + 1)
+                .flatMap(position -> {
+                    if (position <= BATCH_SIZE) {
+                        return queueTokenService.issueToken(userId, scheduleId)
+                                .map(token -> QueueStatusResponse.builder()
+                                        .position(position)
+                                        .status("READY")
+                                        .token(token)
+                                        .estimatedWaitMinutes(0)
+                                        .message("입장 가능합니다")
+                                        .build());
+                    }
+
+                    return Mono.just(QueueStatusResponse.builder()
+                            .position(position)
+                            .status("WAITING")
+                            .estimatedWaitMinutes(calculateEstimatedWait(position))
+                            .aheadCount(position - 1)
+                            .message(String.format("앞에 %d명이 대기 중입니다", position - 1))
+                            .build());
+                });
+    }
+
+    /**
+     * 대기열 취소
+     */
+    public Mono<Boolean> leaveQueue(Long scheduleId, Long userId) {
+        String queueKey = RedisKeyGenerator.queue(scheduleId);
+        String heartbeatKey = RedisKeyGenerator.heartbeat(scheduleId, userId);
+
+        return redisTemplate.opsForZSet()
+                .remove(queueKey, userId.toString())
+                .flatMap(removed -> redisTemplate.delete(heartbeatKey).thenReturn(removed > 0))
+                .doOnSuccess(success -> log.info("대기열 이탈: userId={}, scheduleId={}, success={}",
+                        userId, scheduleId, success));
+    }
+
+    /**
+     * Heartbeat 처리
+     */
+    public Mono<Boolean> heartbeat(Long scheduleId, Long userId) {
+        String heartbeatKey = RedisKeyGenerator.heartbeat(scheduleId, userId);
+
+        return redisTemplate.opsForValue()
+                .set(heartbeatKey, "alive", HEARTBEAT_TTL);
+    }
+
+    private Mono<Long> getPosition(Long scheduleId, Long userId) {
+        String queueKey = RedisKeyGenerator.queue(scheduleId);
+
+        return redisTemplate.opsForZSet()
+                .rank(queueKey, userId.toString())
+                .map(rank -> rank + 1);
+    }
+
+    private int calculateEstimatedWait(long position) {
+        if (position <= BATCH_SIZE) {
+            return 0;
+        }
+        return (int) Math.ceil((position - BATCH_SIZE) / 50.0);
+    }
+}

--- a/src/main/java/com/fairticket/domain/queue/service/QueueTokenService.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueTokenService.java
@@ -1,0 +1,56 @@
+package com.fairticket.domain.queue.service;
+
+import com.fairticket.global.util.RedisKeyGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueTokenService {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+
+    private static final Duration TOKEN_TTL = Duration.ofSeconds(300);
+
+    /**
+     * 입장 토큰 발급
+     */
+    public Mono<String> issueToken(Long userId, Long scheduleId) {
+        String tokenKey = RedisKeyGenerator.queueToken(userId, scheduleId);
+        String tokenValue = UUID.randomUUID().toString();
+
+        return redisTemplate.opsForValue()
+                .set(tokenKey, tokenValue, TOKEN_TTL)
+                .thenReturn(tokenValue)
+                .doOnSuccess(token -> log.info("입장 토큰 발급: userId={}, scheduleId={}", userId, scheduleId));
+    }
+
+    /**
+     * 입장 토큰 검증
+     */
+    public Mono<Boolean> validateToken(Long userId, Long scheduleId, String token) {
+        String tokenKey = RedisKeyGenerator.queueToken(userId, scheduleId);
+
+        return redisTemplate.opsForValue().get(tokenKey)
+                .map(storedToken -> storedToken.equals(token))
+                .defaultIfEmpty(false);
+    }
+
+    /**
+     * 입장 토큰 삭제 (입장 완료 시)
+     */
+    public Mono<Boolean> consumeToken(Long userId, Long scheduleId) {
+        String tokenKey = RedisKeyGenerator.queueToken(userId, scheduleId);
+
+        return redisTemplate.delete(tokenKey)
+                .map(deleted -> deleted > 0)
+                .doOnSuccess(success -> log.info("입장 토큰 소비: userId={}, scheduleId={}", userId, scheduleId));
+    }
+}


### PR DESCRIPTION
 ## Summary
  - Redis SortedSet 기반 FIFO 대기열 시스템 구현
  - 배치 입장 스케줄러 및 비활성 사용자 자동 제거
  - Swagger UI 추가

  ## Changes
  - **QueueService**: 대기열 진입/상태 조회/취소/Heartbeat
  - **QueueTokenService**: 입장 토큰 발급/검증/소비 (TTL 300초)
  - **QueueScheduler**: 배치 입장 처리(5초), 비활성 사용자 제거(10초)
  - **QueueController**: API 4개 엔드포인트
  - **FairticketBeApplication**: `@EnableScheduling` 추가
  - **RedisConfig**: `@Primary` 추가
  - **build.gradle**: `springdoc-openapi-starter-webflux-ui` 추가

  ## API 엔드포인트
  | Method | Path | 설명 |
  |--------|------|------|
  | POST | `/api/v1/queue/{scheduleId}/enter` | 대기열 진입 |
  | GET | `/api/v1/queue/{scheduleId}/status` | 대기열 상태 조회 |
  | DELETE | `/api/v1/queue/{scheduleId}/leave` | 대기열 취소 |
  | POST | `/api/v1/queue/{scheduleId}/heartbeat` | Heartbeat |

  ## 트러블슈팅
  ### 1. ReactiveRedisTemplate 빈 충돌
  - **문제**: `reactiveRedisTemplate`과 `reactiveStringRedisTemplate` 2개 빈이
  존재하여 앱 시작 실패
  - **해결**: `RedisConfig`의 빈에 `@Primary` 추가

  ### 2. 대기열 중복 진입 방지 실패
  - **문제**: `QueueScheduler`가 BATCH_SIZE 이내 유저를 대기열에서 제거하면서,
  중복 진입 체크(SortedSet rank)가 무력화됨
  - **해결**: 진입 시 토큰 존재 여부도 함께 체크 (대기열 rank + 토큰 존재 →
  3단계 검증)

  ## 검증
  
<img width="1489" height="850" alt="스크린샷 2026-02-09 오전 8 35 40" src="https://github.com/user-attachments/assets/c4da8790-ddb6-4b6a-9e12-bc6526ee9376" />

<img width="1526" height="880" alt="스크린샷 2026-02-09 오전 8 36 01" src="https://github.com/user-attachments/assets/5b3a2cb8-2dfc-4559-a74d-dcfedebc92e6" />


  Closes #7