### PR TITLE
feat: 대기열 시스템 및 인증/인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.6'
 	implementation 'org.springframework.kafka:spring-kafka'
+
+	// Security + JWT
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
 	// Redisson (분산 락)
 	implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'

--- a/src/main/java/com/fairticket/FairticketBeApplication.java
+++ b/src/main/java/com/fairticket/FairticketBeApplication.java
@@ -2,8 +2,10 @@ package com.fairticket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class FairticketBeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/fairticket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/fairticket/domain/auth/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.fairticket.domain.auth.controller;
+
+import com.fairticket.domain.auth.dto.AuthResponse;
+import com.fairticket.domain.auth.dto.LoginRequest;
+import com.fairticket.domain.auth.dto.SignupRequest;
+import com.fairticket.domain.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * 인증 API 컨트롤러. 회원가입/로그인 엔드포인트 제공.
+ */
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public Mono<ResponseEntity<AuthResponse>> signup(@Valid @RequestBody SignupRequest request) {
+        return authService.signup(request)
+                .map(response -> ResponseEntity.status(HttpStatus.CREATED).body(response));
+    }
+
+    @PostMapping("/login")
+    public Mono<ResponseEntity<AuthResponse>> login(@Valid @RequestBody LoginRequest request) {
+        return authService.login(request)
+                .map(ResponseEntity::ok);
+    }
+}

--- a/src/main/java/com/fairticket/domain/auth/dto/AuthResponse.java
+++ b/src/main/java/com/fairticket/domain/auth/dto/AuthResponse.java
@@ -1,0 +1,15 @@
+package com.fairticket.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AuthResponse {
+
+    private Long userId;
+    private String email;
+    private String token;
+}

--- a/src/main/java/com/fairticket/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/fairticket/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,21 @@
+package com.fairticket.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+
+    @Schema(example = "user@test.com")
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "이메일 형식이 올바르지 않습니다")
+    private String email;
+
+    @Schema(example = "password123")
+    @NotBlank(message = "비밀번호는 필수입니다")
+    private String password;
+}

--- a/src/main/java/com/fairticket/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/fairticket/domain/auth/dto/SignupRequest.java
@@ -1,0 +1,30 @@
+package com.fairticket.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequest {
+
+    @Schema(example = "user@test.com")
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "이메일 형식이 올바르지 않습니다")
+    private String email;
+
+    @Schema(example = "password123")
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 8, max = 50, message = "비밀번호는 8~50자여야 합니다")
+    private String password;
+
+    @Schema(example = "홍길동")
+    @NotBlank(message = "이름은 필수입니다")
+    private String name;
+
+    @Schema(example = "010-1234-5678")
+    private String phone;
+}

--- a/src/main/java/com/fairticket/domain/auth/service/AuthService.java
+++ b/src/main/java/com/fairticket/domain/auth/service/AuthService.java
@@ -1,0 +1,77 @@
+package com.fairticket.domain.auth.service;
+
+import com.fairticket.domain.auth.dto.AuthResponse;
+import com.fairticket.domain.auth.dto.LoginRequest;
+import com.fairticket.domain.auth.dto.SignupRequest;
+import com.fairticket.domain.user.entity.Role;
+import com.fairticket.domain.user.entity.User;
+import com.fairticket.domain.user.repository.UserRepository;
+import com.fairticket.global.exception.BusinessException;
+import com.fairticket.global.exception.ErrorCode;
+import com.fairticket.global.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+
+/**
+ * 인증 서비스. 회원가입(BCrypt 암호화) 및 로그인(JWT 발급) 처리.
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    /** 회원가입: 이메일 중복 체크 → BCrypt 암호화 → 저장 → JWT 발급 */
+    public Mono<AuthResponse> signup(SignupRequest request) {
+        return userRepository.existsByEmail(request.getEmail())
+                .flatMap(exists -> {
+                    if (exists) {
+                        return Mono.<AuthResponse>error(new BusinessException(ErrorCode.DUPLICATE_EMAIL));
+                    }
+
+                    User user = User.builder()
+                            .email(request.getEmail())
+                            .password(passwordEncoder.encode(request.getPassword()))
+                            .name(request.getName())
+                            .phone(request.getPhone())
+                            .role(Role.USER.name())
+                            .createdAt(LocalDateTime.now())
+                            .updatedAt(LocalDateTime.now())
+                            .build();
+
+                    return userRepository.save(user)
+                            .map(saved -> {
+                                String token = jwtProvider.createToken(saved.getId(), saved.getEmail(), saved.getRole());
+                                return AuthResponse.builder()
+                                        .userId(saved.getId())
+                                        .email(saved.getEmail())
+                                        .token(token)
+                                        .build();
+                            });
+                });
+    }
+
+    /** 로그인: 이메일로 조회 → 비밀번호 검증 → JWT 발급 */
+    public Mono<AuthResponse> login(LoginRequest request) {
+        return userRepository.findByEmail(request.getEmail())
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.UNAUTHORIZED)))
+                .flatMap(user -> {
+                    if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+                        return Mono.<AuthResponse>error(new BusinessException(ErrorCode.UNAUTHORIZED));
+                    }
+
+                    String token = jwtProvider.createToken(user.getId(), user.getEmail(), user.getRole());
+                    return Mono.just(AuthResponse.builder()
+                            .userId(user.getId())
+                            .email(user.getEmail())
+                            .token(token)
+                            .build());
+                });
+    }
+}

--- a/src/main/java/com/fairticket/domain/queue/controller/QueueController.java
+++ b/src/main/java/com/fairticket/domain/queue/controller/QueueController.java
@@ -1,0 +1,73 @@
+package com.fairticket.domain.queue.controller;
+
+import com.fairticket.domain.queue.dto.QueueEntryResponse;
+import com.fairticket.domain.queue.dto.QueueStatusResponse;
+import com.fairticket.domain.queue.service.QueueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/v1/queue")
+@RequiredArgsConstructor
+public class QueueController {
+
+    private final QueueService queueService;
+
+    /**
+     * 대기열 진입
+     * POST /api/v1/queue/{scheduleId}/enter
+     */
+    @PostMapping("/{scheduleId}/enter")
+    public Mono<ResponseEntity<QueueEntryResponse>> enterQueue(
+            @PathVariable Long scheduleId,
+            @RequestHeader("X-User-Id") Long userId) {
+        return queueService.enterQueue(scheduleId, userId)
+                .map(ResponseEntity::ok);
+    }
+
+    /**
+     * 대기열 상태 조회
+     * GET /api/v1/queue/{scheduleId}/status
+     */
+    @GetMapping("/{scheduleId}/status")
+    public Mono<ResponseEntity<QueueStatusResponse>> getStatus(
+            @PathVariable Long scheduleId,
+            @RequestHeader("X-User-Id") Long userId) {
+        return queueService.getQueueStatus(scheduleId, userId)
+                .map(status -> {
+                    if ("READY".equals(status.getStatus())) {
+                        return ResponseEntity.status(HttpStatus.TEMPORARY_REDIRECT)
+                                .header("Location", "/api/v1/reservation/" + scheduleId)
+                                .body(status);
+                    }
+                    return ResponseEntity.ok(status);
+                });
+    }
+
+    /**
+     * 대기열 취소
+     * DELETE /api/v1/queue/{scheduleId}/leave
+     */
+    @DeleteMapping("/{scheduleId}/leave")
+    public Mono<ResponseEntity<Void>> leaveQueue(
+            @PathVariable Long scheduleId,
+            @RequestHeader("X-User-Id") Long userId) {
+        return queueService.leaveQueue(scheduleId, userId)
+                .map(success -> ResponseEntity.noContent().<Void>build());
+    }
+
+    /**
+     * Heartbeat
+     * POST /api/v1/queue/{scheduleId}/heartbeat
+     */
+    @PostMapping("/{scheduleId}/heartbeat")
+    public Mono<ResponseEntity<Void>> heartbeat(
+            @PathVariable Long scheduleId,
+            @RequestHeader("X-User-Id") Long userId) {
+        return queueService.heartbeat(scheduleId, userId)
+                .map(success -> ResponseEntity.ok().<Void>build());
+    }
+}

--- a/src/main/java/com/fairticket/domain/queue/controller/QueueController.java
+++ b/src/main/java/com/fairticket/domain/queue/controller/QueueController.java
@@ -6,6 +6,7 @@ import com.fairticket.domain.queue.service.QueueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
@@ -23,7 +24,7 @@ public class QueueController {
     @PostMapping("/{scheduleId}/enter")
     public Mono<ResponseEntity<QueueEntryResponse>> enterQueue(
             @PathVariable Long scheduleId,
-            @RequestHeader("X-User-Id") Long userId) {
+            @AuthenticationPrincipal Long userId) {
         return queueService.enterQueue(scheduleId, userId)
                 .map(ResponseEntity::ok);
     }
@@ -35,7 +36,7 @@ public class QueueController {
     @GetMapping("/{scheduleId}/status")
     public Mono<ResponseEntity<QueueStatusResponse>> getStatus(
             @PathVariable Long scheduleId,
-            @RequestHeader("X-User-Id") Long userId) {
+            @AuthenticationPrincipal Long userId) {
         return queueService.getQueueStatus(scheduleId, userId)
                 .map(status -> {
                     if ("READY".equals(status.getStatus())) {
@@ -54,7 +55,7 @@ public class QueueController {
     @DeleteMapping("/{scheduleId}/leave")
     public Mono<ResponseEntity<Void>> leaveQueue(
             @PathVariable Long scheduleId,
-            @RequestHeader("X-User-Id") Long userId) {
+            @AuthenticationPrincipal Long userId) {
         return queueService.leaveQueue(scheduleId, userId)
                 .map(success -> ResponseEntity.noContent().<Void>build());
     }
@@ -66,7 +67,7 @@ public class QueueController {
     @PostMapping("/{scheduleId}/heartbeat")
     public Mono<ResponseEntity<Void>> heartbeat(
             @PathVariable Long scheduleId,
-            @RequestHeader("X-User-Id") Long userId) {
+            @AuthenticationPrincipal Long userId) {
         return queueService.heartbeat(scheduleId, userId)
                 .map(success -> ResponseEntity.ok().<Void>build());
     }

--- a/src/main/java/com/fairticket/domain/queue/dto/QueueEntryRequest.java
+++ b/src/main/java/com/fairticket/domain/queue/dto/QueueEntryRequest.java
@@ -1,0 +1,10 @@
+package com.fairticket.domain.queue.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class QueueEntryRequest {
+    private Long scheduleId;
+}

--- a/src/main/java/com/fairticket/domain/queue/dto/QueueEntryResponse.java
+++ b/src/main/java/com/fairticket/domain/queue/dto/QueueEntryResponse.java
@@ -1,0 +1,14 @@
+package com.fairticket.domain.queue.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QueueEntryResponse {
+    private Long scheduleId;
+    private Long userId;
+    private Long position;
+    private Integer estimatedWaitMinutes;
+    private String message;
+}

--- a/src/main/java/com/fairticket/domain/queue/dto/QueueStatusResponse.java
+++ b/src/main/java/com/fairticket/domain/queue/dto/QueueStatusResponse.java
@@ -1,0 +1,15 @@
+package com.fairticket.domain.queue.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QueueStatusResponse {
+    private Long position;
+    private String status;
+    private String token;
+    private Integer estimatedWaitMinutes;
+    private Long aheadCount;
+    private String message;
+}

--- a/src/main/java/com/fairticket/domain/queue/service/QueueScheduler.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueScheduler.java
@@ -1,0 +1,88 @@
+package com.fairticket.domain.queue.service;
+
+import com.fairticket.global.util.RedisKeyGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueScheduler {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final QueueTokenService queueTokenService;
+
+    private static final int BATCH_SIZE = 100;
+    private static final int MAX_ACTIVE_USERS = 500;
+
+    /**
+     * 배치 입장 처리 (5초마다)
+     * active 인원이 MAX_ACTIVE_USERS 미만이면 대기열에서 다음 배치 입장
+     */
+    @Scheduled(fixedDelay = 5000)
+    public void processBatchEntry() {
+        redisTemplate.keys("queue:*")
+                .flatMap(queueKey -> {
+                    String scheduleId = queueKey.split(":")[1];
+                    String activeKey = RedisKeyGenerator.active(Long.parseLong(scheduleId));
+
+                    return redisTemplate.opsForValue().get(activeKey)
+                            .defaultIfEmpty("0")
+                            .map(Integer::parseInt)
+                            .flatMapMany(activeCount -> {
+                                if (activeCount >= MAX_ACTIVE_USERS) {
+                                    return Flux.empty();
+                                }
+
+                                int allowCount = Math.min(BATCH_SIZE, MAX_ACTIVE_USERS - activeCount);
+
+                                return redisTemplate.opsForZSet()
+                                        .range(queueKey, org.springframework.data.domain.Range.closed(0L, (long) allowCount - 1))
+                                        .flatMap(userId -> {
+                                            Long uid = Long.parseLong(userId);
+                                            Long sid = Long.parseLong(scheduleId);
+
+                                            return queueTokenService.issueToken(uid, sid)
+                                                    .then(redisTemplate.opsForZSet().remove(queueKey, userId))
+                                                    .then(redisTemplate.opsForValue().increment(activeKey))
+                                                    .doOnSuccess(v -> log.info("배치 입장: userId={}, scheduleId={}", uid, sid));
+                                        });
+                            });
+                })
+                .subscribe();
+    }
+
+    /**
+     * Heartbeat 미갱신 사용자 대기열 제거 (10초마다)
+     */
+    @Scheduled(fixedDelay = 10000)
+    public void cleanupInactiveUsers() {
+        redisTemplate.keys("queue:*")
+                .flatMap(queueKey -> {
+                    String scheduleId = queueKey.split(":")[1];
+                    Long sid = Long.parseLong(scheduleId);
+
+                    return redisTemplate.opsForZSet()
+                            .range(queueKey, org.springframework.data.domain.Range.closed(0L, -1L))
+                            .flatMap(userId -> {
+                                String heartbeatKey = RedisKeyGenerator.heartbeat(sid, Long.parseLong(userId));
+
+                                return redisTemplate.hasKey(heartbeatKey)
+                                        .flatMap(hasHeartbeat -> {
+                                            if (!hasHeartbeat) {
+                                                return redisTemplate.opsForZSet()
+                                                        .remove(queueKey, userId)
+                                                        .doOnSuccess(v -> log.info("비활성 사용자 제거: userId={}, scheduleId={}",
+                                                                userId, scheduleId));
+                                            }
+                                            return reactor.core.publisher.Mono.empty();
+                                        });
+                            });
+                })
+                .subscribe();
+    }
+}

--- a/src/main/java/com/fairticket/domain/queue/service/QueueService.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueService.java
@@ -1,0 +1,154 @@
+package com.fairticket.domain.queue.service;
+
+import com.fairticket.domain.queue.dto.QueueEntryResponse;
+import com.fairticket.domain.queue.dto.QueueStatusResponse;
+import com.fairticket.global.exception.BusinessException;
+import com.fairticket.global.exception.ErrorCode;
+import com.fairticket.global.util.RedisKeyGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final QueueTokenService queueTokenService;
+
+    private static final int BATCH_SIZE = 100;
+    private static final Duration HEARTBEAT_TTL = Duration.ofSeconds(30);
+
+    /**
+     * 대기열 진입
+     */
+    public Mono<QueueEntryResponse> enterQueue(Long scheduleId, Long userId) {
+        String queueKey = RedisKeyGenerator.queue(scheduleId);
+        String tokenKey = RedisKeyGenerator.queueToken(userId, scheduleId);
+
+        // 1. 토큰 존재 여부 체크 (이미 입장 처리된 유저)
+        return redisTemplate.hasKey(tokenKey)
+                .flatMap(hasToken -> {
+                    if (hasToken) {
+                        return Mono.<QueueEntryResponse>just(QueueEntryResponse.builder()
+                                .scheduleId(scheduleId)
+                                .userId(userId)
+                                .position(0L)
+                                .estimatedWaitMinutes(0)
+                                .message("이미 입장 토큰이 발급되었습니다")
+                                .build());
+                    }
+
+                    // 2. 대기열 존재 여부 체크 (이미 대기 중인 유저)
+                    return redisTemplate.opsForZSet()
+                            .rank(queueKey, userId.toString())
+                            .flatMap(existingRank -> {
+                                long position = existingRank + 1;
+                                return Mono.<QueueEntryResponse>just(QueueEntryResponse.builder()
+                                        .scheduleId(scheduleId)
+                                        .userId(userId)
+                                        .position(position)
+                                        .estimatedWaitMinutes(calculateEstimatedWait(position))
+                                        .message(String.format("이미 대기 중입니다. 현재 %d번째입니다", position))
+                                        .build());
+                            })
+                            .switchIfEmpty(
+                                    // 3. 신규 진입
+                                    Mono.defer(() -> {
+                                        double score = System.currentTimeMillis();
+                                        String heartbeatKey = RedisKeyGenerator.heartbeat(scheduleId, userId);
+
+                                        return redisTemplate.opsForZSet()
+                                                .add(queueKey, userId.toString(), score)
+                                                .then(redisTemplate.opsForValue().set(heartbeatKey, "alive", HEARTBEAT_TTL))
+                                                .then(getPosition(scheduleId, userId))
+                                                .map(position -> QueueEntryResponse.builder()
+                                                        .scheduleId(scheduleId)
+                                                        .userId(userId)
+                                                        .position(position)
+                                                        .estimatedWaitMinutes(calculateEstimatedWait(position))
+                                                        .message(String.format("%d번째로 대기 중입니다", position))
+                                                        .build());
+                                    })
+                            );
+                })
+                .doOnSuccess(response -> log.info("대기열 진입: userId={}, scheduleId={}, position={}",
+                        userId, scheduleId, response.getPosition()));
+    }
+
+    /**
+     * 대기열 상태 조회 (Polling용)
+     */
+    public Mono<QueueStatusResponse> getQueueStatus(Long scheduleId, Long userId) {
+        String queueKey = RedisKeyGenerator.queue(scheduleId);
+
+        return redisTemplate.opsForZSet()
+                .rank(queueKey, userId.toString())
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.NOT_IN_QUEUE)))
+                .map(rank -> rank + 1)
+                .flatMap(position -> {
+                    if (position <= BATCH_SIZE) {
+                        return queueTokenService.issueToken(userId, scheduleId)
+                                .map(token -> QueueStatusResponse.builder()
+                                        .position(position)
+                                        .status("READY")
+                                        .token(token)
+                                        .estimatedWaitMinutes(0)
+                                        .message("입장 가능합니다")
+                                        .build());
+                    }
+
+                    return Mono.just(QueueStatusResponse.builder()
+                            .position(position)
+                            .status("WAITING")
+                            .estimatedWaitMinutes(calculateEstimatedWait(position))
+                            .aheadCount(position - 1)
+                            .message(String.format("앞에 %d명이 대기 중입니다", position - 1))
+                            .build());
+                });
+    }
+
+    /**
+     * 대기열 취소
+     */
+    public Mono<Boolean> leaveQueue(Long scheduleId, Long userId) {
+        String queueKey = RedisKeyGenerator.queue(scheduleId);
+        String heartbeatKey = RedisKeyGenerator.heartbeat(scheduleId, userId);
+
+        return redisTemplate.opsForZSet()
+                .remove(queueKey, userId.toString())
+                .flatMap(removed -> redisTemplate.delete(heartbeatKey).thenReturn(removed > 0))
+                .doOnSuccess(success -> log.info("대기열 이탈: userId={}, scheduleId={}, success={}",
+                        userId, scheduleId, success));
+    }
+
+    /**
+     * Heartbeat 처리
+     */
+    public Mono<Boolean> heartbeat(Long scheduleId, Long userId) {
+        String heartbeatKey = RedisKeyGenerator.heartbeat(scheduleId, userId);
+
+        return redisTemplate.opsForValue()
+                .set(heartbeatKey, "alive", HEARTBEAT_TTL);
+    }
+
+    private Mono<Long> getPosition(Long scheduleId, Long userId) {
+        String queueKey = RedisKeyGenerator.queue(scheduleId);
+
+        return redisTemplate.opsForZSet()
+                .rank(queueKey, userId.toString())
+                .map(rank -> rank + 1);
+    }
+
+    private int calculateEstimatedWait(long position) {
+        if (position <= BATCH_SIZE) {
+            return 0;
+        }
+        return (int) Math.ceil((position - BATCH_SIZE) / 50.0);
+    }
+}

--- a/src/main/java/com/fairticket/domain/queue/service/QueueTokenService.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueTokenService.java
@@ -1,0 +1,56 @@
+package com.fairticket.domain.queue.service;
+
+import com.fairticket.global.util.RedisKeyGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueTokenService {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+
+    private static final Duration TOKEN_TTL = Duration.ofSeconds(300);
+
+    /**
+     * 입장 토큰 발급
+     */
+    public Mono<String> issueToken(Long userId, Long scheduleId) {
+        String tokenKey = RedisKeyGenerator.queueToken(userId, scheduleId);
+        String tokenValue = UUID.randomUUID().toString();
+
+        return redisTemplate.opsForValue()
+                .set(tokenKey, tokenValue, TOKEN_TTL)
+                .thenReturn(tokenValue)
+                .doOnSuccess(token -> log.info("입장 토큰 발급: userId={}, scheduleId={}", userId, scheduleId));
+    }
+
+    /**
+     * 입장 토큰 검증
+     */
+    public Mono<Boolean> validateToken(Long userId, Long scheduleId, String token) {
+        String tokenKey = RedisKeyGenerator.queueToken(userId, scheduleId);
+
+        return redisTemplate.opsForValue().get(tokenKey)
+                .map(storedToken -> storedToken.equals(token))
+                .defaultIfEmpty(false);
+    }
+
+    /**
+     * 입장 토큰 삭제 (입장 완료 시)
+     */
+    public Mono<Boolean> consumeToken(Long userId, Long scheduleId) {
+        String tokenKey = RedisKeyGenerator.queueToken(userId, scheduleId);
+
+        return redisTemplate.delete(tokenKey)
+                .map(deleted -> deleted > 0)
+                .doOnSuccess(success -> log.info("입장 토큰 소비: userId={}, scheduleId={}", userId, scheduleId));
+    }
+}

--- a/src/main/java/com/fairticket/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fairticket/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.fairticket.domain.user.repository;
+
+import com.fairticket.domain.user.entity.User;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface UserRepository extends ReactiveCrudRepository<User, Long> {
+
+    Mono<User> findByEmail(String email);
+
+    Mono<Boolean> existsByEmail(String email);
+}

--- a/src/main/java/com/fairticket/global/config/RedisConfig.java
+++ b/src/main/java/com/fairticket/global/config/RedisConfig.java
@@ -11,6 +11,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
     @Bean
+    @org.springframework.context.annotation.Primary
     public ReactiveRedisTemplate<String, String> reactiveRedisTemplate(
             ReactiveRedisConnectionFactory connectionFactory) {
 

--- a/src/main/java/com/fairticket/global/config/SecurityConfig.java
+++ b/src/main/java/com/fairticket/global/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.fairticket.global.config;
+
+import com.fairticket.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+/**
+ * Spring Security WebFlux 설정.
+ * CSRF/httpBasic/formLogin 비활성화, JWT 필터 등록, 경로별 인가 설정.
+ */
+@Configuration
+@EnableWebFluxSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+                .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+                .authorizeExchange(exchanges -> exchanges
+                        // 인증 불필요
+                        .pathMatchers(HttpMethod.POST, "/api/v1/auth/**").permitAll()
+                        // Actuator
+                        .pathMatchers("/actuator/**").permitAll()
+                        // Swagger (WebFlux)
+                        .pathMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/webjars/**").permitAll()
+                        // 나머지 인증 필요
+                        .anyExchange().authenticated()
+                )
+                .addFilterAt(jwtAuthenticationFilter, SecurityWebFiltersOrder.AUTHENTICATION)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/fairticket/global/config/SwaggerConfig.java
+++ b/src/main/java/com/fairticket/global/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.fairticket.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Swagger(OpenAPI) 설정. JWT Bearer 인증 스키마를 Authorize 버튼으로 노출.
+ */
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String securitySchemeName = "Bearer Token";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("FairTicket API")
+                        .version("v1")
+                        .description("FairTicket 티켓 예매 시스템 API"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+}

--- a/src/main/java/com/fairticket/global/exception/BusinessException.java
+++ b/src/main/java/com/fairticket/global/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.fairticket.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/fairticket/global/exception/ErrorCode.java
+++ b/src/main/java/com/fairticket/global/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다"),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A003", "토큰이 만료되었습니다"),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "A004", "이미 사용 중인 이메일입니다"),
+    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "A005", "요청 한도를 초과했습니다"),
 
     // Queue
     NOT_IN_QUEUE(HttpStatus.NOT_FOUND, "Q001", "대기열에 존재하지 않습니다"),

--- a/src/main/java/com/fairticket/global/exception/ErrorCode.java
+++ b/src/main/java/com/fairticket/global/exception/ErrorCode.java
@@ -1,0 +1,53 @@
+package com.fairticket.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력입니다"),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 오류가 발생했습니다"),
+
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다"),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A003", "토큰이 만료되었습니다"),
+
+    // Queue
+    NOT_IN_QUEUE(HttpStatus.NOT_FOUND, "Q001", "대기열에 존재하지 않습니다"),
+    QUEUE_ENTRY_FAILED(HttpStatus.CONFLICT, "Q002", "대기열 진입에 실패했습니다"),
+    INVALID_QUEUE_TOKEN(HttpStatus.FORBIDDEN, "Q003", "유효하지 않은 입장 토큰입니다"),
+
+    // Reservation
+    ALREADY_PARTICIPATED(HttpStatus.CONFLICT, "R001", "이미 참여한 공연입니다"),
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "R002", "예약을 찾을 수 없습니다"),
+    RESERVATION_CANCELLED(HttpStatus.BAD_REQUEST, "R003", "취소된 예약입니다"),
+
+    // Seat
+    SEAT_ALREADY_TAKEN(HttpStatus.CONFLICT, "S001", "이미 선택된 좌석입니다"),
+    SEAT_HOLD_EXPIRED(HttpStatus.GONE, "S002", "좌석 홀드가 만료되었습니다"),
+    NO_AVAILABLE_SEATS(HttpStatus.NOT_FOUND, "S003", "잔여 좌석이 없습니다"),
+    SOLD_OUT(HttpStatus.GONE, "S004", "매진되었습니다"),
+
+    // Track
+    SAMEDAY_TRACK_CLOSED(HttpStatus.FORBIDDEN, "T001", "당일 트랙이 마감되었습니다"),
+    CART_TRACK_CLOSED(HttpStatus.FORBIDDEN, "T002", "장바구니 트랙이 마감되었습니다"),
+
+    // Payment
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "결제 정보를 찾을 수 없습니다"),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "P002", "결제 금액이 일치하지 않습니다"),
+    PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "P003", "이미 완료된 결제입니다"),
+    PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "P004", "결제 시간이 초과되었습니다"),
+    REFUND_FAILED(HttpStatus.BAD_REQUEST, "P005", "환불 처리에 실패했습니다"),
+
+    // Lock
+    LOCK_ACQUISITION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "L001", "락 획득에 실패했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/fairticket/global/exception/ErrorResponse.java
+++ b/src/main/java/com/fairticket/global/exception/ErrorResponse.java
@@ -1,0 +1,31 @@
+package com.fairticket.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/fairticket/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fairticket/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.support.WebExchangeBindException;
 
 @Slf4j
 @RestControllerAdvice
@@ -16,6 +17,18 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode, e.getMessage()));
+    }
+
+    @ExceptionHandler(WebExchangeBindException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(WebExchangeBindException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("입력값이 올바르지 않습니다");
+        log.warn("Validation failed: {}", message);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/fairticket/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fairticket/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.fairticket.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.error("BusinessException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode, e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unexpected Exception: ", e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_ERROR.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_ERROR));
+    }
+}

--- a/src/main/java/com/fairticket/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fairticket/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.fairticket.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * JWT 인증 WebFilter.
+ * Authorization 헤더에서 Bearer 토큰을 추출하여 검증 후 SecurityContext에 인증 정보를 설정한다.
+ * principal에 userId(Long)를 저장하여 @AuthenticationPrincipal로 꺼낼 수 있다.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements WebFilter {
+
+    private final JwtProvider jwtProvider;
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        String token = resolveToken(exchange.getRequest());
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Long userId = jwtProvider.getUserId(token);
+            String role = jwtProvider.getRole(token);
+
+            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                    userId,
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_" + role))
+            );
+
+            return chain.filter(exchange)
+                    .contextWrite(ReactiveSecurityContextHolder.withAuthentication(auth));
+        }
+
+        return chain.filter(exchange);
+    }
+
+    private String resolveToken(ServerHttpRequest request) {
+        String bearerToken = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/fairticket/global/security/JwtProvider.java
+++ b/src/main/java/com/fairticket/global/security/JwtProvider.java
@@ -1,0 +1,70 @@
+package com.fairticket.global.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성, 검증, 클레임 추출을 담당하는 컴포넌트.
+ * JJWT 라이브러리 기반, HS512 서명 사용.
+ */
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expirationMs;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** subject=userId, claims에 email/role 포함하여 JWT 생성 */
+    public String createToken(Long userId, String email, String role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("email", email)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parser().verifyWith(key).build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public Long getUserId(String token) {
+        return Long.parseLong(getClaims(token).getSubject());
+    }
+
+    public String getRole(String token) {
+        return getClaims(token).get("role", String.class);
+    }
+}

--- a/src/main/java/com/fairticket/global/security/RateLimitFilter.java
+++ b/src/main/java/com/fairticket/global/security/RateLimitFilter.java
@@ -1,0 +1,75 @@
+package com.fairticket.global.security;
+
+import com.fairticket.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+/**
+ * Redis 기반 Rate Limiting WebFilter.
+ * 인증된 유저는 userId, 비인증은 IP 기준으로 분당 60회 제한.
+ * 초과 시 429 Too Many Requests 반환.
+ */
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+@RequiredArgsConstructor
+public class RateLimitFilter implements WebFilter {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+
+    private static final int MAX_REQUESTS_PER_MINUTE = 60;
+    private static final Duration WINDOW = Duration.ofMinutes(1);
+    private static final String RATE_LIMIT_PREFIX = "rate-limit:";
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return ReactiveSecurityContextHolder.getContext()
+                .map(ctx -> ctx.getAuthentication().getPrincipal().toString())
+                .defaultIfEmpty(getClientIp(exchange))
+                .flatMap(identifier -> {
+                    String key = RATE_LIMIT_PREFIX + identifier;
+
+                    return redisTemplate.opsForValue().increment(key)
+                            .flatMap(count -> {
+                                if (count == 1) {
+                                    return redisTemplate.expire(key, WINDOW)
+                                            .thenReturn(count);
+                                }
+                                return Mono.just(count);
+                            })
+                            .flatMap(count -> {
+                                if (count > MAX_REQUESTS_PER_MINUTE) {
+                                    log.warn("Rate limit exceeded: identifier={}, count={}", identifier, count);
+                                    exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
+                                    exchange.getResponse().getHeaders().add("X-RateLimit-Retry-After", "60");
+                                    return exchange.getResponse().setComplete();
+                                }
+
+                                exchange.getResponse().getHeaders().add("X-RateLimit-Remaining",
+                                        String.valueOf(MAX_REQUESTS_PER_MINUTE - count));
+                                return chain.filter(exchange);
+                            });
+                });
+    }
+
+    private String getClientIp(ServerWebExchange exchange) {
+        String forwarded = exchange.getRequest().getHeaders().getFirst("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isEmpty()) {
+            return forwarded.split(",")[0].trim();
+        }
+        var remoteAddress = exchange.getRequest().getRemoteAddress();
+        return remoteAddress != null ? remoteAddress.getAddress().getHostAddress() : "unknown";
+    }
+}

--- a/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
@@ -1,0 +1,27 @@
+package com.fairticket.global.util;
+
+public final class RedisKeyGenerator {
+
+    private RedisKeyGenerator() {}
+
+    private static final String QUEUE_PREFIX = "queue:";
+    private static final String QUEUE_TOKEN_PREFIX = "queue-token:";
+    private static final String HEARTBEAT_PREFIX = "heartbeat:";
+    private static final String ACTIVE_PREFIX = "active:";
+
+    public static String queue(Long scheduleId) {
+        return QUEUE_PREFIX + scheduleId;
+    }
+
+    public static String queueToken(Long userId, Long scheduleId) {
+        return QUEUE_TOKEN_PREFIX + userId + ":" + scheduleId;
+    }
+
+    public static String heartbeat(Long scheduleId, Long userId) {
+        return HEARTBEAT_PREFIX + scheduleId + ":" + userId;
+    }
+
+    public static String active(Long scheduleId) {
+        return ACTIVE_PREFIX + scheduleId;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,11 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
+# JWT
+jwt:
+  secret: fairticket-jwt-secret-key-must-be-at-least-256-bits-long-for-hs256
+  expiration: 3600000  # 1시간 (ms)
+
 # Server
 server:
   port: 8080

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -119,12 +119,12 @@ CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status);
 -- 테스트 데이터
 -- =============================================
 
--- 사용자
+-- 사용자 (BCrypt: password123 / admin123)
 INSERT INTO users (email, password, name, phone, role) VALUES
-    ('test1@test.com', 'password123', '테스트유저1', '010-1234-5678', 'USER'),
-    ('test2@test.com', 'password123', '테스트유저2', '010-2345-6789', 'USER'),
-    ('test3@test.com', 'password123', '테스트유저3', '010-3456-7890', 'USER'),
-    ('admin@test.com', 'admin123', '관리자', '010-0000-0000', 'ADMIN')
+    ('test1@test.com', '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '테스트유저1', '010-1234-5678', 'USER'),
+    ('test2@test.com', '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '테스트유저2', '010-2345-6789', 'USER'),
+    ('test3@test.com', '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '테스트유저3', '010-3456-7890', 'USER'),
+    ('admin@test.com', '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy', '관리자', '010-0000-0000', 'ADMIN')
 ON CONFLICT (email) DO NOTHING;
 
 -- 공연


### PR DESCRIPTION
## Summary      
  - 공통 예외 처리 및 Redis 키 유틸 구현 (#5, #6)
  - Redis 기반 대기열 시스템 구현 (#7, #8)
  - JWT 인증/인가 및 Rate Limiting 구현 (#11, #12)

  ## Changes

  ### Global Infrastructure
  - **ErrorCode**: HttpStatus + code + message 3필드 구조, 전체 도메인 에러코드
  정의 (25개)
  - **GlobalExceptionHandler**: 통합 예외 처리
  - **RedisKeyGenerator**: 대기열 관련 Redis 키 유틸 (queue, queueToken,
  heartbeat, active)
  - **SecurityConfig**: JWT 필터 + Rate Limit 필터 체인
  - **SwaggerConfig**: API 문서화

  ### Auth
  - **AuthController/AuthService**: 회원가입, 로그인
  - **JwtProvider**: HS512 기반 JWT 발급/검증 (1시간 만료)
  - **JwtAuthenticationFilter**: Bearer 토큰 인증 필터
  - **RateLimitFilter**: Redis 기반 60req/min 제한

  ### Queue (대기열)
  - **QueueController/QueueService**: 대기열 진입, 상태 조회, 취소, 하트비트
  - **QueueScheduler**: 5초마다 배치 입장 (최대 100명), 10초마다 비활성 유저
  정리
  - **QueueTokenService**: 입장 토큰 발급/검증/소비 (TTL 5분)

  ### Data
  - **UserRepository**: 이메일 기반 사용자 조회
  - **init.sql**: 테스트 데이터 BCrypt 해시 적용

  ## Includes
  - #6 feat: 공통 예외 처리 및 Redis 키 유틸 구현
  - #8 feat: 대기열 시스템 구현
  - #12 feat: JWT 인증/인가, Rate Limiting 구현 및 누락 코드 복구

  ---
