### PR TITLE
chore: develop 공통 인프라 동기화 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.6'
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.9'
 	implementation 'org.springframework.kafka:spring-kafka'
 
 	// Security + JWT

--- a/src/main/java/com/fairticket/domain/concert/entity/Grade.java
+++ b/src/main/java/com/fairticket/domain/concert/entity/Grade.java
@@ -4,13 +4,13 @@ import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
-@Table("schedule_grades")
+@Table("grades")
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ScheduleGrade {
+public class Grade {
 
     @Id
     private Long id;
@@ -18,8 +18,6 @@ public class ScheduleGrade {
     private Long scheduleId;
 
     private String grade;
-
-    private Integer seatCount;
 
     private Integer price;
 }

--- a/src/main/java/com/fairticket/domain/concert/entity/Schedule.java
+++ b/src/main/java/com/fairticket/domain/concert/entity/Schedule.java
@@ -25,6 +25,8 @@ public class Schedule {
 
     private LocalDateTime ticketOpenAt;
 
+    private LocalDateTime ticketCloseAt;
+
     private String status;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/fairticket/domain/concert/entity/Zone.java
+++ b/src/main/java/com/fairticket/domain/concert/entity/Zone.java
@@ -1,33 +1,25 @@
-package com.fairticket.domain.seat.entity;
+package com.fairticket.domain.concert.entity;
 
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
-import java.time.LocalDateTime;
-
-@Table("seats")
+@Table("zones")
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Seat {
+public class Zone {
 
     @Id
     private Long id;
 
     private Long scheduleId;
 
-    private String grade;
-
     private String zone;
 
-    private String seatNumber;
+    private String grade;
 
-    private Integer price;
-
-    private String status;
-
-    private LocalDateTime createdAt;
+    private Integer seatCount;
 }

--- a/src/main/java/com/fairticket/domain/reservation/entity/ReservationSeat.java
+++ b/src/main/java/com/fairticket/domain/reservation/entity/ReservationSeat.java
@@ -21,6 +21,10 @@ public class ReservationSeat {
 
     private Long seatId;
 
+    private String zone;
+
+    private String seatNumber;
+
     private String status;
 
     private LocalDateTime assignedAt;

--- a/src/main/java/com/fairticket/domain/reservation/entity/TrackType.java
+++ b/src/main/java/com/fairticket/domain/reservation/entity/TrackType.java
@@ -1,6 +1,6 @@
 package com.fairticket.domain.reservation.entity;
 
 public enum TrackType {
-    CART,
-    SAME_DAY
+    LOTTERY,
+    LIVE
 }

--- a/src/main/java/com/fairticket/global/exception/ErrorCode.java
+++ b/src/main/java/com/fairticket/global/exception/ErrorCode.java
@@ -24,20 +24,33 @@ public enum ErrorCode {
     QUEUE_ENTRY_FAILED(HttpStatus.CONFLICT, "Q002", "대기열 진입에 실패했습니다"),
     INVALID_QUEUE_TOKEN(HttpStatus.FORBIDDEN, "Q003", "유효하지 않은 입장 토큰입니다"),
 
+    // Concert / Schedule
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "회차 정보를 찾을 수 없습니다"),
+
     // Reservation
     ALREADY_PARTICIPATED(HttpStatus.CONFLICT, "R001", "이미 참여한 공연입니다"),
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "R002", "예약을 찾을 수 없습니다"),
     RESERVATION_CANCELLED(HttpStatus.BAD_REQUEST, "R003", "취소된 예약입니다"),
 
     // Seat
+    INVALID_ZONE(HttpStatus.BAD_REQUEST, "S000", "유효하지 않은 구역입니다"),
     SEAT_ALREADY_TAKEN(HttpStatus.CONFLICT, "S001", "이미 선택된 좌석입니다"),
     SEAT_HOLD_EXPIRED(HttpStatus.GONE, "S002", "좌석 홀드가 만료되었습니다"),
     NO_AVAILABLE_SEATS(HttpStatus.NOT_FOUND, "S003", "잔여 좌석이 없습니다"),
     SOLD_OUT(HttpStatus.GONE, "S004", "매진되었습니다"),
+    INVALID_GRADE_ZONE(HttpStatus.BAD_REQUEST, "S005", "선택한 등급에 해당 구역이 없습니다"),
+    SEAT_HOLD_NOT_OWNED(HttpStatus.FORBIDDEN, "S006", "본인이 홀드한 좌석만 해제할 수 있습니다"),
 
     // Track
-    SAMEDAY_TRACK_CLOSED(HttpStatus.FORBIDDEN, "T001", "당일 트랙이 마감되었습니다"),
-    CART_TRACK_CLOSED(HttpStatus.FORBIDDEN, "T002", "장바구니 트랙이 마감되었습니다"),
+    LIVE_TRACK_CLOSED(HttpStatus.FORBIDDEN, "T001", "라이브 트랙이 마감되었습니다"),
+    LOTTERY_TRACK_CLOSED(HttpStatus.FORBIDDEN, "T002", "추첨 트랙이 마감되었습니다"),
+    TICKET_NOT_OPENED(HttpStatus.FORBIDDEN, "T003", "아직 티켓 오픈 시간이 아닙니다"),
+    TICKET_CLOSED(HttpStatus.FORBIDDEN, "T004", "티켓 판매가 마감되었습니다"),
+    LOTTERY_ENTRY_CLOSED(HttpStatus.FORBIDDEN, "T005", "추첨 트랙 진입이 마감되었습니다"),
+    LOTTERY_MAX_QUANTITY_EXCEEDED(HttpStatus.BAD_REQUEST, "T006", "추첨 트랙 1인당 최대 2장까지 예매 가능합니다"),
+    LIVE_MAX_QUANTITY_EXCEEDED(HttpStatus.BAD_REQUEST, "T007", "라이브 트랙 1인당 최대 4장까지 예매 가능합니다"),
+    CANCELLATION_NOT_AVAILABLE(HttpStatus.FORBIDDEN, "T008", "추첨/라이브 트랙이 모두 마감된 후에만 취소 신청이 가능합니다"),
+    CANCELLATION_WINDOW_EXPIRED(HttpStatus.FORBIDDEN, "T009", "취소 가능 기간이 지났습니다"),
 
     // Payment
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "결제 정보를 찾을 수 없습니다"),

--- a/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
@@ -4,6 +4,7 @@ public final class RedisKeyGenerator {
 
     private RedisKeyGenerator() {}
 
+    // ===== 대기열 =====
     private static final String QUEUE_PREFIX = "queue:";
     private static final String QUEUE_TOKEN_PREFIX = "queue-token:";
     private static final String HEARTBEAT_PREFIX = "heartbeat:";
@@ -23,5 +24,51 @@ public final class RedisKeyGenerator {
 
     public static String active(Long scheduleId) {
         return ACTIVE_PREFIX + scheduleId;
+    }
+
+    // ===== 좌석 =====
+    private static final String SEATS_PREFIX = "seats:";
+    private static final String HOLD_PREFIX = "hold:";
+    private static final String LOCK_ASSIGN_PREFIX = "lock:assign:";
+
+    public static String seats(Long scheduleId, String zone) {
+        return SEATS_PREFIX + scheduleId + ":" + zone;
+    }
+
+    public static String hold(Long scheduleId, String zone, String seatNo) {
+        return HOLD_PREFIX + scheduleId + ":" + zone + ":" + seatNo;
+    }
+
+    public static String lockAssign(Long scheduleId, String grade) {
+        return LOCK_ASSIGN_PREFIX + scheduleId + ":" + grade;
+    }
+
+    // ===== 트랙 =====
+    private static final String LOTTERY_PAID_PREFIX = "lottery-paid:";
+    private static final String LIVE_CLOSED_PREFIX = "live-closed:";
+    private static final String QUEUE_ZERO_SINCE_PREFIX = "queue-zero-since:";
+    private static final String LOTTERY_ASSIGNED_PREFIX = "lottery-assigned:";
+
+    public static String lotteryPaid(Long scheduleId) {
+        return LOTTERY_PAID_PREFIX + scheduleId;
+    }
+
+    public static String liveClosed(Long scheduleId) {
+        return LIVE_CLOSED_PREFIX + scheduleId;
+    }
+
+    public static String queueZeroSince(Long scheduleId) {
+        return QUEUE_ZERO_SINCE_PREFIX + scheduleId;
+    }
+
+    public static String lotteryAssigned(Long scheduleId) {
+        return LOTTERY_ASSIGNED_PREFIX + scheduleId;
+    }
+
+    // ===== 결제 =====
+    private static final String PAYMENT_TIMER_PREFIX = "payment-timer:";
+
+    public static String paymentTimer(Long reservationId) {
+        return PAYMENT_TIMER_PREFIX + reservationId;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -51,3 +51,15 @@ logging:
     root: INFO
     com.fairticket: DEBUG
     org.springframework.r2dbc: DEBUG
+
+# SpringDoc OpenAPI (Swagger)
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true
+    operations-sorter: method
+    tags-sorter: alpha
+    try-it-out-enabled: true
+    disable-swagger-default-url: true

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,5 +1,5 @@
 -- =============================================
--- FairTicket ERD v3.1
+-- FairTicket ERD v4.0
 -- =============================================
 
 -- 사용자
@@ -24,36 +24,48 @@ CREATE TABLE IF NOT EXISTS concerts (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- 공연 회차
+-- 공연 회차 (total_seats는 SUM(zones.seat_count) 또는 COUNT(seats)와 동기화해 두는 것을 권장)
 CREATE TABLE IF NOT EXISTS schedules (
     id BIGSERIAL PRIMARY KEY,
     concert_id BIGINT NOT NULL REFERENCES concerts(id),
     date_time TIMESTAMP NOT NULL,
     total_seats INT NOT NULL,
     ticket_open_at TIMESTAMP NOT NULL,
+    ticket_close_at TIMESTAMP NOT NULL,
     status VARCHAR(20) NOT NULL DEFAULT 'UPCOMING',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- 등급 설정
-CREATE TABLE IF NOT EXISTS schedule_grades (
+-- 등급 설정 (등급별 가격). 좌석 수는 zones 합산으로 계산
+CREATE TABLE IF NOT EXISTS grades (
     id BIGSERIAL PRIMARY KEY,
     schedule_id BIGINT NOT NULL REFERENCES schedules(id),
     grade VARCHAR(10) NOT NULL,
-    seat_count INT NOT NULL,
     price INT NOT NULL,
     UNIQUE(schedule_id, grade)
 );
 
--- 좌석
+-- 구역 설정 (구역별 등급·좌석 수). 예: VIP-A(200석), S-1(100석)
+CREATE TABLE IF NOT EXISTS zones (
+    id BIGSERIAL PRIMARY KEY,
+    schedule_id BIGINT NOT NULL REFERENCES schedules(id),
+    zone VARCHAR(20) NOT NULL,
+    grade VARCHAR(10) NOT NULL,
+    seat_count INT NOT NULL,
+    UNIQUE(schedule_id, zone)
+);
+
+-- 좌석 (구역별 좌석 번호)
 CREATE TABLE IF NOT EXISTS seats (
     id BIGSERIAL PRIMARY KEY,
     schedule_id BIGINT NOT NULL REFERENCES schedules(id),
     grade VARCHAR(10) NOT NULL,
+    zone VARCHAR(20) NOT NULL,
     seat_number VARCHAR(20) NOT NULL,
     price INT NOT NULL,
     status VARCHAR(20) NOT NULL DEFAULT 'AVAILABLE',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(schedule_id, zone, seat_number)
 );
 
 -- 예약
@@ -69,7 +81,7 @@ CREATE TABLE IF NOT EXISTS reservations (
     confirm_deadline TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(user_id, schedule_id, track_type)
+    UNIQUE(user_id, schedule_id)
 );
 
 -- 예약-좌석
@@ -77,6 +89,8 @@ CREATE TABLE IF NOT EXISTS reservation_seats (
     id BIGSERIAL PRIMARY KEY,
     reservation_id BIGINT NOT NULL REFERENCES reservations(id),
     seat_id BIGINT REFERENCES seats(id),
+    seat_number VARCHAR(20),
+    zone VARCHAR(20),
     status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
     assigned_at TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -85,7 +99,7 @@ CREATE TABLE IF NOT EXISTS reservation_seats (
 CREATE UNIQUE INDEX IF NOT EXISTS uq_reservation_seats_seat_id
     ON reservation_seats(seat_id) WHERE seat_id IS NOT NULL;
 
--- 결제
+-- 결제 (예약당 성공 결제 1건 제한: 동일 reservation_id에 status='COMPLETED'는 1건만 허용)
 CREATE TABLE IF NOT EXISTS payments (
     id BIGSERIAL PRIMARY KEY,
     reservation_id BIGINT NOT NULL REFERENCES reservations(id),
@@ -101,12 +115,18 @@ CREATE TABLE IF NOT EXISTS payments (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE UNIQUE INDEX IF NOT EXISTS uq_payments_reservation_completed
+    ON payments(reservation_id) WHERE status = 'COMPLETED';
+
 -- =============================================
 -- 인덱스
 -- =============================================
 CREATE INDEX IF NOT EXISTS idx_schedules_concert ON schedules(concert_id);
-CREATE INDEX IF NOT EXISTS idx_schedule_grades_schedule ON schedule_grades(schedule_id);
+CREATE INDEX IF NOT EXISTS idx_grades_schedule ON grades(schedule_id);
+CREATE INDEX IF NOT EXISTS idx_zones_schedule ON zones(schedule_id);
+CREATE INDEX IF NOT EXISTS idx_zones_grade ON zones(schedule_id, grade);
 CREATE INDEX IF NOT EXISTS idx_seats_schedule ON seats(schedule_id);
+CREATE INDEX IF NOT EXISTS idx_seats_schedule_zone ON seats(schedule_id, zone);
 CREATE INDEX IF NOT EXISTS idx_seats_status ON seats(status);
 CREATE INDEX IF NOT EXISTS idx_reservations_user ON reservations(user_id);
 CREATE INDEX IF NOT EXISTS idx_reservations_schedule ON reservations(schedule_id);
@@ -129,18 +149,55 @@ ON CONFLICT (email) DO NOTHING;
 
 -- 공연
 INSERT INTO concerts (title, artist, venue) VALUES
-    ('2025 아이유 콘서트', '아이유', '잠실종합운동장')
+    ('2026 아이유 콘서트', '아이유', '잠실종합운동장'),
+    ('2026 블랙핑크 월드투어', 'BLACKPINK', '올림픽공원 체조경기장')
 ON CONFLICT DO NOTHING;
 
 -- 공연 회차
-INSERT INTO schedules (concert_id, date_time, total_seats, ticket_open_at, status) VALUES
-    (1, '2025-03-15 19:00:00', 1000, '2025-02-15 20:00:00', 'UPCOMING')
+INSERT INTO schedules (concert_id, date_time, total_seats, ticket_open_at, ticket_close_at, status) VALUES
+    (1, '2026-03-15 19:00:00', 1000, '2026-02-09 20:00:00', '2026-03-15 18:00:00', 'OPEN'),
+    (2, '2026-04-20 18:00:00', 1500, '2026-02-20 20:00:00', '2026-04-20 17:00:00', 'UPCOMING'),
+    (1, '2026-01-10 19:00:00', 800, '2025-12-01 20:00:00', '2026-01-10 18:00:00', 'CLOSED')
 ON CONFLICT DO NOTHING;
 
 -- 등급 설정
-INSERT INTO schedule_grades (schedule_id, grade, seat_count, price) VALUES
-    (1, 'VIP', 100, 150000),
-    (1, 'R', 200, 120000),
-    (1, 'S', 300, 90000),
-    (1, 'A', 400, 60000)
+INSERT INTO grades (schedule_id, grade, price) VALUES
+    (1, 'VIP', 120000),
+    (1, 'S', 90000),
+    (1, 'A', 60000),
+    (2, 'VIP', 150000),
+    (2, 'S', 100000),
+    (2, 'A', 70000),
+    (3, 'VIP', 120000),
+    (3, 'S', 90000),
+    (3, 'A', 60000)
 ON CONFLICT (schedule_id, grade) DO NOTHING;
+
+-- 구역 설정
+INSERT INTO zones (schedule_id, zone, grade, seat_count) VALUES
+    (1, 'A', 'VIP', 200), (1, 'B', 'VIP', 200), (1, 'C', 'VIP', 200), (1, 'D', 'VIP', 200), (1, 'E', 'VIP', 200), (1, 'F', 'VIP', 200), (1, 'G', 'VIP', 200), (1, 'H', 'VIP', 200),
+    (1, '3', 'VIP', 100), (1, '4', 'VIP', 100), (1, '5', 'VIP', 100), (1, '6', 'VIP', 100), (1, '7', 'VIP', 100), (1, '8', 'VIP', 100), (1, '9', 'VIP', 100), (1, '10', 'VIP', 100), (1, '11', 'VIP', 100), (1, '12', 'VIP', 100), (1, '13', 'VIP', 100),
+    (1, '1', 'S', 100), (1, '2', 'S', 100), (1, '14', 'S', 100), (1, '15', 'S', 100),
+    (1, '27', 'S', 100), (1, '28', 'S', 100), (1, '29', 'S', 100), (1, '30', 'S', 100), (1, '31', 'S', 100), (1, '32', 'S', 100), (1, '33', 'S', 100), (1, '34', 'S', 100), (1, '35', 'S', 100), (1, '36', 'S', 100), (1, '37', 'S', 100), (1, '38', 'S', 100), (1, '39', 'S', 100), (1, '40', 'S', 100),
+    (1, '24', 'A', 100), (1, '25', 'A', 100), (1, '26', 'A', 100), (1, '41', 'A', 100), (1, '42', 'A', 100), (1, '43', 'A', 100),
+    (2, 'A', 'VIP', 200), (2, 'B', 'VIP', 200), (2, 'C', 'VIP', 200), (2, 'D', 'VIP', 200), (2, 'E', 'VIP', 200), (2, 'F', 'VIP', 200), (2, 'G', 'VIP', 200), (2, 'H', 'VIP', 200),
+    (2, '3', 'VIP', 100), (2, '4', 'VIP', 100), (2, '5', 'VIP', 100), (2, '6', 'VIP', 100), (2, '7', 'VIP', 100), (2, '8', 'VIP', 100), (2, '9', 'VIP', 100), (2, '10', 'VIP', 100), (2, '11', 'VIP', 100), (2, '12', 'VIP', 100), (2, '13', 'VIP', 100),
+    (2, '1', 'S', 100), (2, '2', 'S', 100), (2, '14', 'S', 100), (2, '15', 'S', 100),
+    (2, '27', 'S', 100), (2, '28', 'S', 100), (2, '29', 'S', 100), (2, '30', 'S', 100), (2, '31', 'S', 100), (2, '32', 'S', 100), (2, '33', 'S', 100), (2, '34', 'S', 100), (2, '35', 'S', 100), (2, '36', 'S', 100), (2, '37', 'S', 100), (2, '38', 'S', 100), (2, '39', 'S', 100), (2, '40', 'S', 100),
+    (2, '24', 'A', 100), (2, '25', 'A', 100), (2, '26', 'A', 100), (2, '41', 'A', 100), (2, '42', 'A', 100), (2, '43', 'A', 100),
+    (3, 'A', 'VIP', 200), (3, 'B', 'VIP', 200), (3, 'C', 'VIP', 200), (3, 'D', 'VIP', 200), (3, 'E', 'VIP', 200), (3, 'F', 'VIP', 200), (3, 'G', 'VIP', 200), (3, 'H', 'VIP', 200),
+    (3, '3', 'VIP', 100), (3, '4', 'VIP', 100), (3, '5', 'VIP', 100), (3, '6', 'VIP', 100), (3, '7', 'VIP', 100), (3, '8', 'VIP', 100), (3, '9', 'VIP', 100), (3, '10', 'VIP', 100), (3, '11', 'VIP', 100), (3, '12', 'VIP', 100), (3, '13', 'VIP', 100),
+    (3, '1', 'S', 100), (3, '2', 'S', 100), (3, '14', 'S', 100), (3, '15', 'S', 100),
+    (3, '27', 'S', 100), (3, '28', 'S', 100), (3, '29', 'S', 100), (3, '30', 'S', 100), (3, '31', 'S', 100), (3, '32', 'S', 100), (3, '33', 'S', 100), (3, '34', 'S', 100), (3, '35', 'S', 100), (3, '36', 'S', 100), (3, '37', 'S', 100), (3, '38', 'S', 100), (3, '39', 'S', 100), (3, '40', 'S', 100),
+    (3, '24', 'A', 100), (3, '25', 'A', 100), (3, '26', 'A', 100), (3, '41', 'A', 100), (3, '42', 'A', 100), (3, '43', 'A', 100)
+ON CONFLICT (schedule_id, zone) DO NOTHING;
+
+-- 좌석 (schedule_id, grade, zone, seat_number)
+INSERT INTO seats (schedule_id, grade, zone, seat_number, price, status) VALUES
+    (1, 'VIP', 'A', '1', 120000, 'AVAILABLE'), (1, 'VIP', 'A', '2', 120000, 'HELD'), (1, 'VIP', 'A', '3', 120000, 'SOLD'), (1, 'VIP', 'A', '4', 120000, 'AVAILABLE'), (1, 'VIP', 'A', '5', 120000, 'AVAILABLE'),
+    (1, 'VIP', 'B', '1', 120000, 'AVAILABLE'), (1, 'VIP', 'B', '2', 120000, 'AVAILABLE'), (1, 'VIP', 'B', '3', 120000, 'HELD'),
+    (1, 'S', '1', '1', 90000, 'AVAILABLE'), (1, 'S', '1', '2', 90000, 'SOLD'), (1, 'S', '1', '3', 90000, 'AVAILABLE'), (1, 'S', '2', '1', 90000, 'HELD'),
+    (1, 'A', '24', '1', 60000, 'SOLD'), (1, 'A', '24', '2', 60000, 'AVAILABLE'), (1, 'A', '41', '1', 60000, 'AVAILABLE'), (1, 'A', '41', '2', 60000, 'HELD'),
+    (2, 'VIP', 'A', '1', 150000, 'AVAILABLE'), (2, 'VIP', 'A', '2', 150000, 'SOLD'), (2, 'VIP', 'B', '1', 150000, 'HELD'),
+    (2, 'S', '1', '1', 100000, 'AVAILABLE'), (2, 'S', '1', '2', 100000, 'SOLD'), (2, 'A', '24', '1', 70000, 'AVAILABLE'), (2, 'A', '41', '1', 70000, 'HELD'),
+    (3, 'VIP', 'A', '1', 120000, 'HELD'), (3, 'VIP', 'B', '1', 120000, 'AVAILABLE'), (3, 'S', '1', '1', 90000, 'AVAILABLE'), (3, 'A', '24', '1', 60000, 'SOLD');


### PR DESCRIPTION
  ## Summary                                                                    
  - feat/#10(좌석/예매), feat/#9(결제) 브랜치와의 머지 충돌을 최소화하기 위해
  공통 인프라를 선행 정리                                                     
  - DB 스키마 v4.0 반영, ErrorCode/RedisKeyGenerator 병합, Entity 동기화 
                                                                       
  ## Changes                                                         

  ### DB 스키마 (init.sql)
  - `schedule_grades` → `grades` + `zones` 테이블 분리
  - `schedules`: `ticket_close_at` 컬럼 추가
  - `seats`: `zone` 컬럼 추가, UNIQUE 제약조건 변경
  - `reservation_seats`: `seat_number`, `zone` 컬럼 추가
  - `reservations`: UNIQUE 제약조건 변경 (`user_id, schedule_id, track_type` →
  `user_id, schedule_id`)
  - `payments`: 완료 결제 1건 제한 UNIQUE INDEX 추가
  - 테스트 데이터 BCrypt 비밀번호 유지 + 블랙핑크 콘서트 추가

  ### Entity
  - `ScheduleGrade.java` 삭제 → `Grade.java`, `Zone.java` 신규 추가
  - `Schedule`: `ticketCloseAt` 필드 추가
  - `Seat`: `zone` 필드 추가
  - `ReservationSeat`: `seatNumber`, `zone` 필드 추가
  - `TrackType`: CART/SAME_DAY → LOTTERY/LIVE

  ### 공통 코드
  - `ErrorCode.java`: queue-system(25개) + seat-assignment(12개) 병합 → 37개
  - `RedisKeyGenerator.java`: 대기열 키 + 좌석/트랙/결제 키 병합 (상수 prefix
  컨벤션 통일)

  ### 설정
  - `build.gradle`: springdoc 2.8.6 → 2.8.9
  - `application.yaml`: springdoc OpenAPI 설정 추가

  ## 수정하지 않은 범위
  - 좌석/예매 기능 코드 (Controller, Service) → feat/#10에서 처리
  - 결제 기능 코드 → feat/#9에서 처리

  ## 관련
  - #13 feat: 기본 결제 시스템 구현
  - #16 feat: 로터리 트랙 및 라이브 트랙 좌석 예매 기능 구현
  - #17 [Chore] develop 브랜치 공통 인프라 동기화