### PR TITLE
feat: 기본 결제 시스템 구현 (PortOne PG 연동, 결제 타이머, 환불)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0'
 
 	// Redisson (분산 락)
 	implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - "6379:6379"
     volumes:
       - redis_data:/data
-    command: redis-server --appendonly yes
+    command: redis-server --appendonly yes --notify-keyspace-events Ex
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s

--- a/src/main/java/com/fairticket/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/fairticket/domain/payment/controller/PaymentController.java
@@ -1,0 +1,68 @@
+package com.fairticket.domain.payment.controller;
+
+import com.fairticket.domain.payment.dto.PaymentCompleteRequest;
+import com.fairticket.domain.payment.dto.PaymentInitResponse;
+import com.fairticket.domain.payment.entity.Payment;
+import com.fairticket.domain.payment.service.PaymentService;
+import com.fairticket.domain.payment.service.PortOneClient;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "Payment", description = "결제 API")
+@RestController
+@RequestMapping("/api/v1/payment")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @Operation(
+            summary = "결제 준비",
+            description = "예약 ID를 기반으로 결제를 준비하고 merchantUid를 발급합니다. 장바구니는 5분, 당일은 10분 타이머가 시작됩니다."
+    )
+    @PostMapping("/prepare")
+    public Mono<ResponseEntity<PaymentInitResponse>> preparePayment(
+            @Parameter(description = "예약 ID", required = true)
+            @RequestParam Long reservationId,
+
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader("X-User-Id") Long userId) {
+        return paymentService.initiatePayment(reservationId, userId)
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(
+            summary = "결제 완료 처리",
+            description = "PortOne PG사를 통한 결제 완료 후 Webhook으로 호출됩니다. 결제 금액을 검증하고 예약 상태를 업데이트합니다."
+    )
+    @PostMapping("/complete")
+    public Mono<ResponseEntity<Payment>> completePayment(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "PortOne 결제 완료 정보",
+                    required = true
+            )
+            @RequestBody PaymentCompleteRequest request) {
+        return paymentService.completePayment(request)
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(
+            summary = "결제 환불",
+            description = "완료된 결제를 환불 처리합니다. PortOne을 통해 실제 환불이 진행됩니다."
+    )
+    @PostMapping("/{paymentId}/refund")
+    public Mono<ResponseEntity<PortOneClient.RefundResult>> refundPayment(
+            @Parameter(description = "결제 ID", required = true)
+            @PathVariable Long paymentId,
+
+            @Parameter(description = "환불 사유", example = "사용자 요청")
+            @RequestParam(defaultValue = "사용자 요청") String reason) {
+        return paymentService.refundPayment(paymentId, reason)
+                .map(ResponseEntity::ok);
+    }
+}

--- a/src/main/java/com/fairticket/domain/payment/dto/PaymentCompleteRequest.java
+++ b/src/main/java/com/fairticket/domain/payment/dto/PaymentCompleteRequest.java
@@ -1,0 +1,11 @@
+package com.fairticket.domain.payment.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PaymentCompleteRequest {
+    private String impUid;      // PortOne 결제 고유번호
+    private String merchantUid; // 우리 시스템 주문번호
+}

--- a/src/main/java/com/fairticket/domain/payment/dto/PaymentInitResponse.java
+++ b/src/main/java/com/fairticket/domain/payment/dto/PaymentInitResponse.java
@@ -1,0 +1,14 @@
+package com.fairticket.domain.payment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaymentInitResponse {
+    private String merchantUid;
+    private Integer amount;
+    private String itemName;
+    private Long paymentId;
+    private Integer timeoutSeconds; // 결제 제한 시간
+}

--- a/src/main/java/com/fairticket/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/fairticket/domain/payment/entity/PaymentStatus.java
@@ -1,8 +1,9 @@
 package com.fairticket.domain.payment.entity;
 
 public enum PaymentStatus {
-    PENDING,
-    COMPLETED,
-    FAILED,
-    REFUNDED
+    PENDING,      // 결제 대기
+    COMPLETED,    // 결제 완료
+    FAILED,       // PG 결제 실패 (카드 한도, 인증 실패)
+    CANCELLED,    // 타임아웃으로 자동 취소
+    REFUNDED      // 환불 완료
 }

--- a/src/main/java/com/fairticket/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/fairticket/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,16 @@
+package com.fairticket.domain.payment.repository;
+
+import com.fairticket.domain.payment.entity.Payment;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface PaymentRepository extends ReactiveCrudRepository<Payment, Long> {
+
+    Mono<Payment> findByMerchantUid(String merchantUid);
+
+    Mono<Payment> findByReservationId(Long reservationId);
+
+    Flux<Payment> findByStatus(String status);
+
+}

--- a/src/main/java/com/fairticket/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PaymentService.java
@@ -1,0 +1,148 @@
+package com.fairticket.domain.payment.service;
+
+import com.fairticket.domain.payment.dto.PaymentCompleteRequest;
+import com.fairticket.domain.payment.dto.PaymentInitResponse;
+import com.fairticket.domain.payment.entity.Payment;
+import com.fairticket.domain.payment.entity.PaymentStatus;
+import com.fairticket.domain.payment.repository.PaymentRepository;
+import com.fairticket.domain.reservation.entity.Reservation;
+import com.fairticket.domain.reservation.entity.TrackType;
+import com.fairticket.domain.reservation.repository.ReservationRepository;
+// import com.fairticket.domain.reservation.service.CartTrackService; // TODO: B 작업 후 주석 해제
+import com.fairticket.global.exception.BusinessException;
+import com.fairticket.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final ReservationRepository reservationRepository;
+    private final PortOneClient portOneClient;
+    private final PaymentTimerService timerService;
+    // private final CartTrackService cartTrackService; // TODO: B 작업 후 주석 해제
+
+    // 결제 준비 (결제창 호출 전)
+    public Mono<PaymentInitResponse> initiatePayment(Long reservationId, Long userId) {
+        return reservationRepository.findById(reservationId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.RESERVATION_NOT_FOUND)))
+                .flatMap(reservation -> {
+                    int amount = calculateAmount(reservation);
+                    String merchantUid = generateMerchantUid();
+                    TrackType trackType = TrackType.valueOf(reservation.getTrackType());
+
+                    Payment payment = Payment.builder()
+                            .reservationId(reservationId)
+                            .merchantUid(merchantUid)
+                            .amount(amount)
+                            .status(PaymentStatus.PENDING.name())
+                            .createdAt(LocalDateTime.now())
+                            .build();
+
+                    return paymentRepository.save(payment)
+                            .flatMap(saved -> {
+                                // 타이머 시작 (reservationId 전달)
+                                return timerService.startPaymentTimer(reservationId, trackType)
+                                        .thenReturn(saved);
+                            })
+                            .map(saved -> PaymentInitResponse.builder()
+                                    .paymentId(saved.getId())
+                                    .merchantUid(saved.getMerchantUid())
+                                    .amount(saved.getAmount())
+                                    .itemName(String.format("%s %d매 티켓",
+                                            reservation.getGrade(),
+                                            reservation.getQuantity()))
+                                    .timeoutSeconds(trackType == TrackType.CART ? 300 : 600)
+                                    .build());
+                });
+    }
+
+    // 결제 완료 처리 (Webhook)
+    public Mono<Payment> completePayment(PaymentCompleteRequest request) {
+        return paymentRepository.findByMerchantUid(request.getMerchantUid())
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND)))
+                // PG사 검증
+                .flatMap(payment -> portOneClient.verifyPayment(request.getImpUid())
+                        .flatMap(verification -> {
+                            // 금액 검증
+                            if (!payment.getAmount().equals(verification.getAmount())) {
+                                log.error("결제 금액 불일치: expected={}, actual={}",
+                                        payment.getAmount(),
+                                        verification.getAmount());
+                                return Mono.error(new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH));
+                            }
+
+                            // 결제 정보 업데이트
+                            payment.setImpUid(request.getImpUid());
+                            payment.setStatus(PaymentStatus.COMPLETED.name());
+                            payment.setPaidAt(LocalDateTime.now());
+                            return paymentRepository.save(payment);
+                        }))
+                // 타이머 취소
+                .flatMap(payment -> reservationRepository.findById(payment.getReservationId())
+                        .flatMap(reservation -> timerService.cancelPaymentTimer(reservation.getId())
+                                .thenReturn(payment)))
+                // B 콜백 (장바구니 트랙인 경우)
+                .flatMap(payment -> reservationRepository.findById(payment.getReservationId())
+                        .flatMap(reservation -> {
+                            if (TrackType.CART.name().equals(reservation.getTrackType())) {
+                                // TODO: B 작업 후 주석 해제
+                                // return cartTrackService.onPaymentCompleted(
+                                //         reservation.getId(),
+                                //         reservation.getUserId(),
+                                //         reservation.getScheduleId()
+                                // ).thenReturn(payment);
+
+                                log.info("장바구니 결제 완료 (B 연동 대기중): reservationId={}", reservation.getId());
+                                return Mono.just(payment);
+                            }
+                            // 당일 트랙은 별도 처리 없음
+                            return Mono.just(payment);
+                        }))
+                .doOnSuccess(payment -> log.info("결제 완료 처리: paymentId={}, merchantUid={}",
+                        payment.getId(), payment.getMerchantUid()));
+    }
+
+    // 환불 처리
+    public Mono<PortOneClient.RefundResult> refundPayment(Long paymentId, String reason) {
+        return paymentRepository.findById(paymentId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND)))
+                .flatMap(payment -> portOneClient.cancelPayment(
+                        payment.getImpUid(),
+                        payment.getAmount(),
+                        reason
+                ).flatMap(result -> {
+                    if (result.isSuccess()) {
+                        payment.setStatus(PaymentStatus.REFUNDED.name());
+                        payment.setUpdatedAt(LocalDateTime.now());
+                        return paymentRepository.save(payment)
+                                .thenReturn(result);
+                    }
+                    return Mono.just(result);
+                }));
+    }
+
+    private String generateMerchantUid() {
+        return "FAIR_" + System.currentTimeMillis() + "_" +
+                UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private int calculateAmount(Reservation reservation) {
+        int unitPrice = switch (reservation.getGrade()) {
+            case "VIP" -> 150000;
+            case "R" -> 120000;
+            case "S" -> 90000;
+            case "A" -> 60000;
+            default -> 0;
+        };
+        return unitPrice * reservation.getQuantity();
+    }
+}

--- a/src/main/java/com/fairticket/domain/payment/service/PaymentTimerService.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PaymentTimerService.java
@@ -1,0 +1,54 @@
+package com.fairticket.domain.payment.service;
+
+import com.fairticket.domain.reservation.entity.TrackType;
+import com.fairticket.global.util.RedisKeyGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+public class PaymentTimerService {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    public PaymentTimerService(
+            @Qualifier("reactiveRedisTemplate") ReactiveRedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // 결제 타이머 시작
+    public Mono<Void> startPaymentTimer(Long reservationId, TrackType trackType) {
+        String timerKey = RedisKeyGenerator.paymentTimer(reservationId);
+        Duration ttl = trackType == TrackType.CART
+                ? Duration.ofMinutes(5)
+                : Duration.ofMinutes(10);
+
+        return redisTemplate.opsForValue()
+                .set(timerKey, "PENDING", ttl)
+                .doOnSuccess(v -> log.info("결제 타이머 시작: reservationId={}, ttl={}분",
+                        reservationId, ttl.toMinutes()))
+                .then();
+    }
+
+    // 결제 타이머 취소 (결제 완료 시)
+    public Mono<Boolean> cancelPaymentTimer(Long reservationId) {
+        String timerKey = RedisKeyGenerator.paymentTimer(reservationId);
+        return redisTemplate.delete(timerKey)
+                .map(deleted -> deleted > 0)
+                .doOnSuccess(success -> log.info("결제 타이머 취소: reservationId={}", reservationId));
+    }
+
+    // 남은 시간 조회 (초 단위)
+    public Mono<Long> getRemainingTime(Long reservationId) {
+        String timerKey = RedisKeyGenerator.paymentTimer(reservationId);
+        return redisTemplate.getExpire(timerKey)
+                .map(Duration::getSeconds);
+    }
+}

--- a/src/main/java/com/fairticket/domain/payment/service/PortOneClient.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PortOneClient.java
@@ -1,0 +1,128 @@
+package com.fairticket.domain.payment.service;
+
+import com.fairticket.domain.payment.entity.PaymentStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import jakarta.annotation.PostConstruct;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class PortOneClient {
+
+    private WebClient webClient;
+
+    @Value("${fairticket.portone.api-key}")
+    private String apiKey;
+
+    @Value("${fairticket.portone.api-secret}")
+    private String apiSecret;
+
+    @Value("${fairticket.portone.test-mode:true}")
+    private boolean testMode;
+
+    private static final String PORTONE_API_URL = "https://api.iamport.kr";
+
+    @PostConstruct
+    public void init() {
+        this.webClient = WebClient.builder()
+                .baseUrl(PORTONE_API_URL)
+                .build();
+
+        if (testMode) {
+            log.warn("PortOne 테스트 모드로 실행 중입니다.");
+        }
+    }
+
+    // 액세스 토큰 발급
+    public Mono<String> getAccessToken() {
+        return webClient.post()
+                .uri("/users/getToken")
+                .bodyValue(Map.of(
+                        "imp_key", apiKey,
+                        "imp_secret", apiSecret
+                ))
+                .retrieve()
+                .bodyToMono(Map.class)
+                .map(response -> {
+                    Map<String, Object> responseBody = (Map<String, Object>) response.get("response");
+                    return (String) responseBody.get("access_token");
+                })
+                .doOnSuccess(token -> log.debug("PortOne 액세스 토큰 발급 완료"))
+                .doOnError(error -> log.error("PortOne 토큰 발급 실패", error));
+    }
+
+    // 결제 검증
+    public Mono<PaymentVerificationResult> verifyPayment(String impUid) {
+        return getAccessToken()
+                .flatMap(token -> webClient.get()
+                        .uri("/payments/" + impUid)
+                        .header("Authorization", "Bearer " + token)
+                        .retrieve()
+                        .bodyToMono(Map.class)
+                        .map(response -> {
+                            Map<String, Object> data = (Map<String, Object>) response.get("response");
+                            return PaymentVerificationResult.builder()
+                                    .impUid(impUid)
+                                    .merchantUid((String) data.get("merchant_uid"))
+                                    .amount(((Number) data.get("amount")).intValue())
+                                    .status(mapStatus((String) data.get("status")))
+                                    .build();
+                        }))
+                .doOnSuccess(result -> log.info("결제 검증 완료: impUid={}, status={}",
+                        impUid, result.getStatus()));
+    }
+
+    // 결제 취소 (환불)
+    public Mono<RefundResult> cancelPayment(String impUid, int amount, String reason) {
+        return getAccessToken()
+                .flatMap(token -> webClient.post()
+                        .uri("/payments/cancel")
+                        .header("Authorization", "Bearer " + token)
+                        .bodyValue(Map.of(
+                                "imp_uid", impUid,
+                                "amount", amount,
+                                "reason", reason
+                        ))
+                        .retrieve()
+                        .bodyToMono(Map.class)
+                        .map(response -> {
+                            Integer code = (Integer) response.get("code");
+                            return RefundResult.builder()
+                                    .success(code == 0)
+                                    .message((String) response.get("message"))
+                                    .build();
+                        }))
+                .doOnSuccess(result -> log.info("환불 처리 완료: impUid={}, success={}",
+                        impUid, result.isSuccess()));
+    }
+
+    private PaymentStatus mapStatus(String portoneStatus) {
+        return switch (portoneStatus) {
+            case "paid" -> PaymentStatus.COMPLETED;
+            case "cancelled" -> PaymentStatus.REFUNDED;
+            case "failed" -> PaymentStatus.FAILED;
+            default -> PaymentStatus.PENDING;
+        };
+    }
+
+    @lombok.Builder
+    @lombok.Getter
+    public static class PaymentVerificationResult {
+        private String impUid;
+        private String merchantUid;
+        private Integer amount;
+        private PaymentStatus status;
+    }
+
+    @lombok.Builder
+    @lombok.Getter
+    public static class RefundResult {
+        private boolean success;
+        private String message;
+    }
+}

--- a/src/main/java/com/fairticket/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/fairticket/domain/reservation/entity/Reservation.java
@@ -6,34 +6,31 @@ import org.springframework.data.relational.core.mapping.Table;
 
 import java.time.LocalDateTime;
 
-@Table("reservations")
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table("reservations")
 public class Reservation {
 
     @Id
     private Long id;
 
     private Long userId;
-
     private Long scheduleId;
 
-    private String grade;
+    // 좌석 정보
+    private String grade;                    // VIP, R, S, A
+    private Integer quantity;                // 좌석 수량
+    private Boolean needsConsecutiveSeats;   // 연속 좌석 필요 여부
+    private String seatNumbers;              // ⭐ 추가! (예: "127,128" 또는 "127")
 
-    private String trackType;
+    // 트랙 정보
+    private String trackType;                // CART, SAME_DAY
+    private String status;                   // PENDING, PAID_PENDING_SEAT, CONFIRMED, CANCELLED
 
-    private String status;
-
-    private Integer quantity;
-
-    private Boolean needsConfirm;
-
-    private LocalDateTime confirmDeadline;
-
+    // 시간 정보
     private LocalDateTime createdAt;
-
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/fairticket/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/fairticket/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,19 @@
+package com.fairticket.domain.reservation.repository;
+
+import com.fairticket.domain.reservation.entity.Reservation;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface ReservationRepository extends ReactiveCrudRepository<Reservation, Long> {
+
+    Flux<Reservation> findByUserId(Long userId);
+
+    Flux<Reservation> findByScheduleIdAndStatus(Long scheduleId, String status);
+
+    @Query("SELECT * FROM reservations WHERE status = :status AND quantity = :quantity")
+    Flux<Reservation> findByStatusAndQuantity(String status, Integer quantity);
+
+    Mono<Boolean> existsByUserIdAndScheduleIdAndStatusIn(Long userId, Long scheduleId, String... statuses);
+}

--- a/src/main/java/com/fairticket/domain/seat/service/SeatPoolService.java
+++ b/src/main/java/com/fairticket/domain/seat/service/SeatPoolService.java
@@ -1,0 +1,14 @@
+package com.fairticket.domain.seat.service;
+
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+public class SeatPoolService {
+
+    //좌석 반환 (취소/타임아웃 시)
+    public Mono<Boolean> returnSeat(Long scheduleId, String grade, String seatNumber) {
+        // TODO: B 구현 대기
+        return Mono.just(true);
+    }
+}

--- a/src/main/java/com/fairticket/global/config/RedisConfig.java
+++ b/src/main/java/com/fairticket/global/config/RedisConfig.java
@@ -3,7 +3,9 @@ package com.fairticket.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -25,5 +27,18 @@ public class RedisConfig {
                 .build();
 
         return new ReactiveRedisTemplate<>(connectionFactory, context);
+    }
+
+    /**
+     * Redis Key 만료 이벤트 리스너 컨테이너 (신규)
+     * RedisKeyExpiredListener가 Key 만료 이벤트를 받을 수 있게 함
+     */
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
     }
 }

--- a/src/main/java/com/fairticket/global/config/SwaggerConfig.java
+++ b/src/main/java/com/fairticket/global/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.fairticket.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("FairTicket API")
+                        .description("공정한 티켓팅 시스템 API 문서")
+                        .version("1.0.0")
+                        .contact(new Contact()
+                                .name("FairTicket Team")
+                                .email("fairticket@example.com")))
+                .servers(List.of(
+                        new Server()
+                                .url("http://localhost:8080")
+                                .description("로컬 개발 서버")
+                ));
+    }
+}

--- a/src/main/java/com/fairticket/global/exception/BusinessException.java
+++ b/src/main/java/com/fairticket/global/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.fairticket.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/fairticket/global/exception/ErrorCode.java
+++ b/src/main/java/com/fairticket/global/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.fairticket.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // Payment 관련
+    PAYMENT_NOT_FOUND("P001", "결제 정보를 찾을 수 없습니다."),
+    PAYMENT_AMOUNT_MISMATCH("P002", "결제 금액이 일치하지 않습니다."),
+
+    // Reservation 관련
+    ALREADY_PARTICIPATED("R001", "이미 참여한 공연입니다."),
+    RESERVATION_NOT_FOUND("R002", "예약 정보를 찾을 수 없습니다."),
+
+    // 공통
+    INTERNAL_SERVER_ERROR("C002", "서버 내부 오류가 발생했습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
@@ -1,0 +1,48 @@
+package com.fairticket.global.util;
+
+public class RedisKeyGenerator {
+
+    public static String queue(Long scheduleId) {
+        return String.format("queue:%d", scheduleId);
+    }
+
+    public static String token(Long userId, Long scheduleId) {
+        return String.format("token:%d:%d", userId, scheduleId);
+    }
+
+    public static String heartbeat(Long scheduleId, Long userId) {
+        return String.format("heartbeat:%d:%d", scheduleId, userId);
+    }
+
+    public static String seatPool(Long scheduleId, String grade) {
+        return String.format("seats:%d:%s", scheduleId, grade);
+    }
+
+    public static String stock(Long scheduleId, String grade) {
+        return String.format("stock:%d:%s", scheduleId, grade);
+    }
+
+    public static String seatHold(Long scheduleId, String grade, String seatNumber) {
+        return String.format("hold:%d:%s:%s", scheduleId, grade, seatNumber);
+    }
+
+    public static String soldSameday(Long scheduleId) {
+        return String.format("sold:sameday:%d", scheduleId);
+    }
+
+    public static String remaining(Long scheduleId) {
+        return String.format("remaining:%d", scheduleId);
+    }
+
+    public static String lockAssign(Long scheduleId, String grade) {
+        return String.format("lock:assign:%d:%s", scheduleId, grade);
+    }
+
+    public static String cartPaid(Long scheduleId) {
+        return String.format("cart-paid:%d", scheduleId);
+    }
+
+    public static String paymentTimer(Long reservationId) {
+        return String.format("payment-timer:%d", reservationId);
+    }
+}

--- a/src/main/java/com/fairticket/infra/redis/RedisKeyExpiredListener.java
+++ b/src/main/java/com/fairticket/infra/redis/RedisKeyExpiredListener.java
@@ -1,0 +1,123 @@
+package com.fairticket.infra.redis;
+
+import com.fairticket.domain.payment.entity.PaymentStatus;
+import com.fairticket.domain.payment.repository.PaymentRepository;
+import com.fairticket.domain.reservation.entity.ReservationStatus;
+import com.fairticket.domain.reservation.repository.ReservationRepository;
+import com.fairticket.domain.seat.service.SeatPoolService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisKeyExpiredEvent;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisKeyExpiredListener {
+
+    private final PaymentRepository paymentRepository;
+    private final ReservationRepository reservationRepository;
+    private final SeatPoolService seatPoolService;
+
+    // Redis Key 만료 이벤트 리스너
+    @EventListener
+    public void onKeyExpired(RedisKeyExpiredEvent<String> event) {
+        String key = new String(event.getSource());
+
+        log.info("Redis Key 만료 이벤트: {}", key);
+
+        if (key.startsWith("payment-timer:")) {
+            handlePaymentTimeout(key);
+        } else if (key.startsWith("hold:")) {
+            handleHoldExpired(key);
+        }
+    }
+
+    // 결제 타임아웃 처리
+    private void handlePaymentTimeout(String key) {
+        try {
+            // payment-timer:123 → 123 추출
+            Long reservationId = Long.parseLong(key.split(":")[1]);
+
+            log.warn("⏰ 결제 타임아웃 발생: reservationId={}", reservationId);
+
+            reservationRepository.findById(reservationId)
+                    .flatMap(reservation -> {
+                        // Reservation 취소
+                        reservation.setStatus(ReservationStatus.CANCELLED.name());
+                        reservation.setUpdatedAt(LocalDateTime.now());
+
+                        return reservationRepository.save(reservation)
+                                .flatMap(savedReservation ->
+                                        // Payment도 취소
+                                        paymentRepository.findByReservationId(reservationId)
+                                                .flatMap(payment -> {
+                                                    if (PaymentStatus.PENDING.name().equals(payment.getStatus())) {
+                                                        payment.setStatus(PaymentStatus.CANCELLED.name());
+                                                        payment.setUpdatedAt(LocalDateTime.now());
+                                                        return paymentRepository.save(payment);
+                                                    }
+                                                    return paymentRepository.save(payment);
+                                                })
+                                                .then(restoreSeat(savedReservation))
+                                );
+                    })
+                    .doOnSuccess(v -> log.info("결제 타임아웃 처리 완료: reservationId={}", reservationId))
+                    .doOnError(error -> log.error("결제 타임아웃 처리 실패: reservationId={}", reservationId, error))
+                    .subscribe();
+
+        } catch (Exception e) {
+            log.error("결제 타임아웃 처리 중 오류: key={}", key, e);
+        }
+    }
+
+    // 좌석 홀드 만료 처리 (당일 트랙용)
+    private void handleHoldExpired(String key) {
+        try {
+            // hold:1:R:127 → [hold, 1, R, 127]
+            String[] parts = key.split(":");
+            Long scheduleId = Long.parseLong(parts[1]);
+            String grade = parts[2];
+            String seatNumber = parts[3];
+
+            log.warn("좌석 홀드 만료: schedule={}, grade={}, seat={}",
+                    scheduleId, grade, seatNumber);
+
+            seatPoolService.returnSeat(scheduleId, grade, seatNumber)
+                    .doOnSuccess(result ->
+                            log.info("좌석 반환 완료: seat={}", seatNumber))
+                    .doOnError(error ->
+                            log.error("좌석 반환 실패: seat={}", seatNumber, error))
+                    .subscribe();
+
+        } catch (Exception e) {
+            log.error("좌석 홀드 만료 처리 중 오류: key={}", key, e);
+        }
+    }
+
+    // 좌석 반환 (당일 트랙만)
+    private reactor.core.publisher.Mono<Void> restoreSeat(
+            com.fairticket.domain.reservation.entity.Reservation reservation) {
+
+        // 당일 트랙이고 좌석 번호가 있으면 반환
+        if ("SAME_DAY".equals(reservation.getTrackType()) &&
+                reservation.getSeatNumbers() != null) {
+
+            log.info("좌석 반환 시작: schedule={}, grade={}, seats={}",
+                    reservation.getScheduleId(),
+                    reservation.getGrade(),
+                    reservation.getSeatNumbers());
+
+            return seatPoolService.returnSeat(
+                    reservation.getScheduleId(),
+                    reservation.getGrade(),
+                    reservation.getSeatNumbers()
+            ).then();
+        }
+
+        return reactor.core.publisher.Mono.empty();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,3 +46,10 @@ logging:
     root: INFO
     com.fairticket: DEBUG
     org.springframework.r2dbc: DEBUG
+
+# PortOne 설정 추가
+fairticket:
+  portone:
+    api-key: ${PORTONE_API_KEY}
+    api-secret: ${PORTONE_API_SECRET}
+    test-mode: true


### PR DESCRIPTION
  ## Summary
  - PortOne PG사 연동 기반 결제 준비/완료/환불 시스템 구현 (#9, #13)
  - Redis Key 만료 기반 결제 타임아웃 자동 취소 구현
  - Redis keyspace notification 기반 좌석 홀드 만료 처리

  ## Changes

  ### Payment
  - **PaymentController**: 결제 준비(`POST /prepare`), 결제 완료(`POST
  /complete`), 환불(`POST /{paymentId}/refund`)
  - **PaymentService**: merchantUid 발급, PG 금액 검증, 결제 상태 관리, 환불
  처리
  - **PortOneClient**: PortOne API 토큰 발급, 결제 검증, 결제 취소(환불)
  WebClient 구현
  - **PaymentTimerService**: Redis TTL 기반 결제 제한 시간 타이머 (추첨 5분 /
  라이브 10분)
  - **PaymentRepository**: merchantUid·reservationId 기반 조회
  - **PaymentStatus**: CANCELLED 상태 추가

  ### Infrastructure
  - **RedisKeyExpiredListener**: Redis keyspace notification 기반 Key 만료
  이벤트 리스너 (결제 타임아웃 → 예약/결제 취소 + 좌석 반환, 좌석 홀드 만료 →
  좌석 반환)
  - **RedisConfig**: RedisMessageListenerContainer 빈 추가
  - **docker-compose.yml**: Redis `notify-keyspace-events Ex` 설정 추가
  - **application.yaml**: PortOne API 키 설정 추가

  ### Data
  - **Reservation Entity**: seatNumbers 필드 추가
  - **ReservationRepository**: 결제 연동용 조회 메서드

  ## Includes
  - #13 feat: 기본 결제 시스템 구현