### PR TITLE
refactor: 예약 취소 API를 POST에서 DELETE로 변경

### DIFF
--- a/src/main/java/com/fairticket/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/fairticket/domain/reservation/controller/ReservationController.java
@@ -17,7 +17,7 @@ public class ReservationController {
     private final CancellationWindowService cancellationWindowService;
 
     // 예약 취소 (추첨/라이브 공통). 티켓 오픈 2시간 후 ~ 24시간 이내만 가능.
-    @PostMapping("/{reservationId}/cancel")
+    @DeleteMapping("/{reservationId}")
     public Mono<ResponseEntity<Void>> cancelReservation(
             @PathVariable Long reservationId,
             @RequestHeader("X-User-Id") Long userId) {


### PR DESCRIPTION
## Summary
예약 취소 API를 REST 관례에 맞게 **POST**에서 **DELETE**로 변경했습니다.

## Changes
- `ReservationController.java`  
  - `@PostMapping("/{reservationId}/cancel")` → `@DeleteMapping("/{reservationId}")`

## API
| 구분 | 변경 전 | 변경 후 |
|------|---------|---------|
| **HTTP 메서드** | `POST` | `DELETE` |
| **엔드포인트** | `POST /api/v1/reservations/{reservationId}/cancel` | `DELETE /api/v1/reservations/{reservationId}` |
| **응답** | `204 No Content` | `204 No Content` (동일) |

## 관련 Issue
#21