### PR TITLE
feat: 결제 시스템 완성 - 타이머 정책 수정 · 불일치 복구 · 조회 API · 추첨 연동

### DIFF
--- a/src/main/java/com/fairticket/domain/payment/dto/PaymentTimerResponse.java
+++ b/src/main/java/com/fairticket/domain/payment/dto/PaymentTimerResponse.java
@@ -1,0 +1,13 @@
+package com.fairticket.domain.payment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaymentTimerResponse {
+
+    private Long reservationId;
+    private Long remainingSeconds;
+    private boolean expired;
+}

--- a/src/main/java/com/fairticket/domain/payment/service/PaymentTimerService.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PaymentTimerService.java
@@ -1,5 +1,6 @@
 package com.fairticket.domain.payment.service;
 
+import com.fairticket.domain.reservation.constants.ReservationConstants;
 import com.fairticket.domain.reservation.entity.TrackType;
 import com.fairticket.global.util.RedisKeyGenerator;
 import lombok.extern.slf4j.Slf4j;
@@ -23,12 +24,10 @@ public class PaymentTimerService {
         this.redisTemplate = redisTemplate;
     }
 
-    // 결제 타이머 시작 (추첨 5분, 라이브 10분)
+    // 결제 타이머 시작 (추첨/라이브 공통 5분)
     public Mono<Void> startPaymentTimer(Long reservationId, TrackType trackType) {
         String timerKey = RedisKeyGenerator.paymentTimerKey(reservationId);
-        Duration ttl = trackType == TrackType.LOTTERY
-                ? Duration.ofMinutes(5)
-                : Duration.ofMinutes(10);
+        Duration ttl = Duration.ofMinutes(ReservationConstants.PAYMENT_DEADLINE_MINUTES);
 
         return redisTemplate.opsForValue()
                 .set(timerKey, "PENDING", ttl)

--- a/src/main/java/com/fairticket/domain/payment/service/PaymentTimerService.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PaymentTimerService.java
@@ -2,6 +2,8 @@ package com.fairticket.domain.payment.service;
 
 import com.fairticket.domain.reservation.constants.ReservationConstants;
 import com.fairticket.domain.reservation.entity.TrackType;
+import com.fairticket.global.exception.BusinessException;
+import com.fairticket.global.exception.ErrorCode;
 import com.fairticket.global.util.RedisKeyGenerator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +29,10 @@ public class PaymentTimerService {
     // 결제 타이머 시작 (추첨/라이브 공통 5분)
     public Mono<Void> startPaymentTimer(Long reservationId, TrackType trackType) {
         String timerKey = RedisKeyGenerator.paymentTimerKey(reservationId);
+        // 타임라인 기준 결제 제한 시간: 추첨/라이브 공통 5분
+        // Duration ttl = trackType == TrackType.LOTTERY
+        //         ? Duration.ofMinutes(5)
+        //         : Duration.ofMinutes(10);  // 라이브 10분 → 5분으로 수정 (타임라인 기준)
         Duration ttl = Duration.ofMinutes(ReservationConstants.PAYMENT_DEADLINE_MINUTES);
 
         return redisTemplate.opsForValue()
@@ -45,9 +51,17 @@ public class PaymentTimerService {
     }
 
     // 남은 시간 조회 (초 단위)
+    // Redis 키가 없으면 → 타이머 만료 또는 미시작 → PAYMENT_TIMEOUT 에러
     public Mono<Long> getRemainingTime(Long reservationId) {
         String timerKey = RedisKeyGenerator.paymentTimerKey(reservationId);
         return redisTemplate.getExpire(timerKey)
-                .map(Duration::getSeconds);
+                .flatMap(duration -> {
+                    long seconds = duration.getSeconds();
+                    // Redis 키 없음: -1(키 없음) 또는 -2(만료됨) 반환
+                    if (seconds < 0) {
+                        return Mono.error(new BusinessException(ErrorCode.PAYMENT_TIMEOUT));
+                    }
+                    return Mono.just(seconds);
+                });
     }
 }

--- a/src/main/java/com/fairticket/domain/payment/service/PaymentVerificationScheduler.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PaymentVerificationScheduler.java
@@ -1,0 +1,94 @@
+package com.fairticket.domain.payment.service;
+
+import com.fairticket.domain.payment.entity.PaymentStatus;
+import com.fairticket.domain.payment.repository.PaymentRepository;
+import com.fairticket.domain.reservation.entity.ReservationStatus;
+import com.fairticket.domain.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentVerificationScheduler {
+
+    private final PaymentRepository paymentRepository;
+    private final ReservationRepository reservationRepository;
+    private final PortOneClient portOneClient;
+
+    @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
+    public void verifyPendingPayments() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(5);
+
+        paymentRepository.findByStatus(PaymentStatus.PENDING.name())
+                .filter(payment -> payment.getCreatedAt() != null
+                        && payment.getCreatedAt().isBefore(threshold))
+                .filter(payment -> payment.getImpUid() != null)
+                .flatMap(payment -> portOneClient.verifyPayment(payment.getImpUid())
+                        .flatMap(verification -> {
+                            switch (verification.getStatus()) {
+                                case COMPLETED -> {
+                                    // PG에서 결제 완료 → DB 동기화
+                                    log.info("결제 불일치 복구 - 완료 처리: paymentId={}, impUid={}",
+                                            payment.getId(), payment.getImpUid());
+                                    payment.setStatus(PaymentStatus.COMPLETED.name());
+                                    payment.setPaidAt(LocalDateTime.now());
+                                    return paymentRepository.save(payment)
+                                            .flatMap(saved -> updateReservationStatus(
+                                                    saved.getReservationId(), ReservationStatus.PAID.name()));
+                                }
+                                case FAILED -> {
+                                    // PG에서 결제 실패 → DB 동기화
+                                    log.warn("결제 불일치 복구 - 실패 처리: paymentId={}, impUid={}",
+                                            payment.getId(), payment.getImpUid());
+                                    payment.setStatus(PaymentStatus.FAILED.name());
+                                    payment.setUpdatedAt(LocalDateTime.now());
+                                    return paymentRepository.save(payment)
+                                            .flatMap(saved -> updateReservationStatus(
+                                                    saved.getReservationId(), ReservationStatus.CANCELLED.name()));
+                                }
+                                default -> {
+                                    // 아직 처리 중 → Redis TTL 만료로 처리 대기
+                                    log.debug("결제 검증 대기 중: paymentId={}, status={}",
+                                            payment.getId(), verification.getStatus());
+                                    return Mono.just(payment);
+                                }
+                            }
+                        })
+                        .onErrorResume(e -> {
+                            log.warn("결제 검증 API 호출 실패: paymentId={}, error={}",
+                                    payment.getId(), e.getMessage());
+                            return Mono.just(payment);
+                        }))
+                .doOnSubscribe(s -> log.debug("결제 불일치 복구 스캔 시작"))
+                .count()
+                .doOnSuccess(count -> {
+                    if (count > 0) {
+                        log.info("결제 불일치 복구 처리: {}건", count);
+                    }
+                })
+                .onErrorResume(e -> {
+                    log.warn("결제 불일치 복구 스케줄러 오류: {}", e.getMessage());
+                    return Mono.just(0L);
+                })
+                .subscribe();
+    }
+
+    private Mono<Void> updateReservationStatus(Long reservationId, String status) {
+        return reservationRepository.findById(reservationId)
+                .flatMap(reservation -> {
+                    reservation.setStatus(status);
+                    reservation.setUpdatedAt(LocalDateTime.now());
+                    return reservationRepository.save(reservation);
+                })
+                .doOnSuccess(r -> log.info("예약 상태 업데이트: reservationId={}, status={}",
+                        reservationId, status))
+                .then();
+    }
+}


### PR DESCRIPTION
## Summary
결제 타이머 버그 수정부터 미결제 자동 취소, 결제 불일치 복구, 조회 API 추가, 추첨 결제 완료 후속 처리 연동까지 결제 시스템 완성

## Changes
- `PaymentTimerService`: 추첨/라이브 타이머 `PAYMENT_DEADLINE_MINUTES` 상수로 통일, Redis 키 없을 때 `P004` 에러 반환
- `PaymentService`: `timeoutSeconds` 상수 적용, 추첨 결제 완료 시 `LotteryTrackService.onPaymentCompleted()` 연동
- `PaymentVerificationScheduler`: PENDING 결제 1분마다 PortOne 검증 폴링, COMPLETED/FAILED 불일치 시 DB 자동 동기화 
- `PaymentController`: 결제 단건 조회(관리자용), 예약 기준 결제 조회,  타이머 남은 시간 조회 API 추가
- `PaymentTimerResponse`: 타이머 조회 응답 DTO 추가 

## Closes
#25 