### PR TITLE
feat: 대기열 시스템 고도화 및 인증 개선

### DIFF
--- a/src/main/java/com/fairticket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/fairticket/domain/auth/controller/AuthController.java
@@ -6,17 +6,16 @@ import com.fairticket.domain.auth.dto.SignupRequest;
 import com.fairticket.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
-/**
- * 인증 API 컨트롤러. 회원가입/로그인 엔드포인트 제공.
- */
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -34,5 +33,16 @@ public class AuthController {
     public Mono<ResponseEntity<AuthResponse>> login(@Valid @RequestBody LoginRequest request) {
         return authService.login(request)
                 .map(ResponseEntity::ok);
+    }
+
+    @PostMapping("/logout")
+    public Mono<ResponseEntity<Void>> logout(ServerHttpRequest request) {
+        String bearerToken = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7);
+            return authService.logout(token)
+                    .then(Mono.just(ResponseEntity.noContent().<Void>build()));
+        }
+        return Mono.just(ResponseEntity.noContent().<Void>build());
     }
 }

--- a/src/main/java/com/fairticket/domain/auth/dto/AuthResponse.java
+++ b/src/main/java/com/fairticket/domain/auth/dto/AuthResponse.java
@@ -11,5 +11,7 @@ public class AuthResponse {
 
     private Long userId;
     private String email;
+    private String name;
+    private String role;
     private String token;
 }

--- a/src/main/java/com/fairticket/domain/queue/config/QueueProperties.java
+++ b/src/main/java/com/fairticket/domain/queue/config/QueueProperties.java
@@ -17,4 +17,6 @@ public class QueueProperties {
     private int heartbeatTtlSeconds = 30;
     private int tokenTtlSeconds = 300;
     private int activeTimeoutSeconds = 60;
+    private int schedulerIntervalMs = 5000;
+    private int cleanupIntervalMs = 10000;
 }

--- a/src/main/java/com/fairticket/domain/queue/config/QueueProperties.java
+++ b/src/main/java/com/fairticket/domain/queue/config/QueueProperties.java
@@ -1,0 +1,20 @@
+package com.fairticket.domain.queue.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "fairticket.queue")
+public class QueueProperties {
+
+    private int batchSize = 100;
+    private int maxActiveUsers = 500;
+    private int maxQueueSize = 100000;
+    private int heartbeatTtlSeconds = 30;
+    private int tokenTtlSeconds = 300;
+    private int activeTimeoutSeconds = 60;
+}

--- a/src/main/java/com/fairticket/domain/queue/service/QueueScheduler.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueScheduler.java
@@ -1,12 +1,26 @@
 package com.fairticket.domain.queue.service;
 
+import com.fairticket.domain.queue.config.QueueProperties;
 import com.fairticket.global.util.RedisKeyGenerator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import jakarta.annotation.PostConstruct;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -15,74 +29,135 @@ public class QueueScheduler {
 
     private final ReactiveRedisTemplate<String, String> redisTemplate;
     private final QueueTokenService queueTokenService;
+    private final QueueProperties queueProperties;
+    private final RedissonClient redissonClient;
+    private final ObjectMapper objectMapper;
 
-    private static final int BATCH_SIZE = 100;
-    private static final int MAX_ACTIVE_USERS = 500;
+    private RedisScript<String> batchAdmitScript;
+
+    @PostConstruct
+    public void init() {
+        batchAdmitScript = RedisScript.of(new ClassPathResource("scripts/batch_admit.lua"), String.class);
+    }
 
     /**
      * 배치 입장 처리 (5초마다)
-     * active 인원이 MAX_ACTIVE_USERS 미만이면 대기열에서 다음 배치 입장
+     * Redisson 분산 락으로 단일 인스턴스만 실행
+     * Lua Script로 원자적 큐→active 이동
      */
-    @Scheduled(fixedDelay = 5000)
+    @Scheduled(fixedDelayString = "${fairticket.queue.scheduler-interval-ms:5000}")
     public void processBatchEntry() {
-        redisTemplate.keys("queue:*")
-                .flatMap(queueKey -> {
-                    String scheduleId = queueKey.split(":")[1];
-                    String activeKey = RedisKeyGenerator.activeKey(Long.parseLong(scheduleId));
+        RLock lock = redissonClient.getLock("scheduler:batch-entry");
+        boolean acquired = false;
+        try {
+            acquired = lock.tryLock(0, 4, TimeUnit.SECONDS);
+            if (!acquired) return;
 
-                    return redisTemplate.opsForValue().get(activeKey)
-                            .defaultIfEmpty("0")
-                            .map(Integer::parseInt)
-                            .flatMapMany(activeCount -> {
-                                if (activeCount >= MAX_ACTIVE_USERS) {
-                                    return Flux.empty();
-                                }
+            redisTemplate.opsForSet()
+                    .members(RedisKeyGenerator.activeSchedulesKey())
+                    .flatMap(this::processBatchForSchedule)
+                    .collectList()
+                    .block(Duration.ofSeconds(4));
 
-                                int allowCount = Math.min(BATCH_SIZE, MAX_ACTIVE_USERS - activeCount);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.error("배치 입장 처리 실패", e);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
 
-                                return redisTemplate.opsForZSet()
-                                        .range(queueKey, org.springframework.data.domain.Range.closed(0L, (long) allowCount - 1))
-                                        .flatMap(userId -> {
-                                            Long uid = Long.parseLong(userId);
-                                            Long sid = Long.parseLong(scheduleId);
+    private Mono<Void> processBatchForSchedule(String scheduleIdStr) {
+        Long scheduleId = Long.parseLong(scheduleIdStr);
+        String activeKey = RedisKeyGenerator.activeKey(scheduleId);
+        String queueKey = RedisKeyGenerator.queueKey(scheduleId);
+        long now = System.currentTimeMillis();
 
-                                            return queueTokenService.issueToken(uid, sid)
-                                                    .then(redisTemplate.opsForZSet().remove(queueKey, userId))
-                                                    .then(redisTemplate.opsForValue().increment(activeKey))
-                                                    .doOnSuccess(v -> log.info("배치 입장: userId={}, scheduleId={}", uid, sid));
-                                        });
-                            });
+        return redisTemplate.execute(
+                        batchAdmitScript,
+                        List.of(activeKey, queueKey),
+                        List.of(
+                                String.valueOf(queueProperties.getMaxActiveUsers()),
+                                String.valueOf(queueProperties.getBatchSize()),
+                                String.valueOf(now),
+                                String.valueOf(queueProperties.getActiveTimeoutSeconds() * 1000L)
+                        ))
+                .next()
+                .flatMap(result -> {
+                    try {
+                        Map<String, Object> parsed = objectMapper.readValue(
+                                result, new TypeReference<Map<String, Object>>() {});
+                        @SuppressWarnings("unchecked")
+                        List<String> admitted = (List<String>) parsed.get("admitted");
+                        int activeCount = ((Number) parsed.get("activeCount")).intValue();
+                        int queueSize = ((Number) parsed.get("queueSize")).intValue();
+
+                        if (!admitted.isEmpty()) {
+                            log.info("배치 입장: scheduleId={}, admitted={}, active={}, queue={}",
+                                    scheduleId, admitted.size(), activeCount, queueSize);
+                        }
+
+                        return Flux.fromIterable(admitted)
+                                .flatMap(userId -> queueTokenService.issueToken(Long.parseLong(userId), scheduleId))
+                                .then();
+                    } catch (Exception e) {
+                        log.error("Lua Script 결과 파싱 실패: scheduleId={}", scheduleId, e);
+                        return Mono.empty();
+                    }
                 })
-                .subscribe();
+                .doOnError(e -> log.error("배치 입장 실패: scheduleId={}", scheduleId, e))
+                .onErrorResume(e -> Mono.empty());
     }
 
     /**
      * Heartbeat 미갱신 사용자 대기열 제거 (10초마다)
+     * SMEMBERS active-schedules로 대상 스케줄 조회 (KEYS 대체)
      */
-    @Scheduled(fixedDelay = 10000)
+    @Scheduled(fixedDelayString = "${fairticket.queue.cleanup-interval-ms:10000}")
     public void cleanupInactiveUsers() {
-        redisTemplate.keys("queue:*")
-                .flatMap(queueKey -> {
-                    String scheduleId = queueKey.split(":")[1];
-                    Long sid = Long.parseLong(scheduleId);
+        RLock lock = redissonClient.getLock("scheduler:cleanup");
+        boolean acquired = false;
+        try {
+            acquired = lock.tryLock(0, 9, TimeUnit.SECONDS);
+            if (!acquired) return;
 
-                    return redisTemplate.opsForZSet()
-                            .range(queueKey, org.springframework.data.domain.Range.closed(0L, -1L))
-                            .flatMap(userId -> {
-                                String heartbeatKey = RedisKeyGenerator.heartbeatKey(sid, Long.parseLong(userId));
+            redisTemplate.opsForSet()
+                    .members(RedisKeyGenerator.activeSchedulesKey())
+                    .flatMap(scheduleIdStr -> {
+                        Long scheduleId = Long.parseLong(scheduleIdStr);
+                        String queueKey = RedisKeyGenerator.queueKey(scheduleId);
 
-                                return redisTemplate.hasKey(heartbeatKey)
-                                        .flatMap(hasHeartbeat -> {
-                                            if (!hasHeartbeat) {
-                                                return redisTemplate.opsForZSet()
-                                                        .remove(queueKey, userId)
-                                                        .doOnSuccess(v -> log.info("비활성 사용자 제거: userId={}, scheduleId={}",
-                                                                userId, scheduleId));
-                                            }
-                                            return reactor.core.publisher.Mono.empty();
-                                        });
-                            });
-                })
-                .subscribe();
+                        return redisTemplate.opsForZSet()
+                                .range(queueKey, org.springframework.data.domain.Range.closed(0L, -1L))
+                                .flatMap(userId -> {
+                                    String heartbeatKey = RedisKeyGenerator.heartbeatKey(scheduleId, Long.parseLong(userId));
+
+                                    return redisTemplate.hasKey(heartbeatKey)
+                                            .flatMap(hasHeartbeat -> {
+                                                if (!hasHeartbeat) {
+                                                    return redisTemplate.opsForZSet()
+                                                            .remove(queueKey, userId)
+                                                            .doOnSuccess(v -> log.info("비활성 사용자 제거: userId={}, scheduleId={}",
+                                                                    userId, scheduleId));
+                                                }
+                                                return Mono.empty();
+                                            });
+                                });
+                    })
+                    .collectList()
+                    .block(Duration.ofSeconds(9));
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.error("비활성 사용자 정리 실패", e);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 }

--- a/src/main/java/com/fairticket/domain/queue/service/QueueService.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueService.java
@@ -1,5 +1,6 @@
 package com.fairticket.domain.queue.service;
 
+import com.fairticket.domain.queue.config.QueueProperties;
 import com.fairticket.domain.queue.dto.QueueEntryResponse;
 import com.fairticket.domain.queue.dto.QueueStatusResponse;
 import com.fairticket.global.exception.BusinessException;
@@ -20,9 +21,7 @@ public class QueueService {
 
     private final ReactiveRedisTemplate<String, String> redisTemplate;
     private final QueueTokenService queueTokenService;
-
-    private static final int BATCH_SIZE = 100;
-    private static final Duration HEARTBEAT_TTL = Duration.ofSeconds(30);
+    private final QueueProperties queueProperties;
 
     /**
      * 대기열 진입
@@ -31,7 +30,6 @@ public class QueueService {
         String queueKey = RedisKeyGenerator.queueKey(scheduleId);
         String tokenKey = RedisKeyGenerator.tokenKey(userId, scheduleId);
 
-        // 1. 토큰 존재 여부 체크 (이미 입장 처리된 유저)
         return redisTemplate.hasKey(tokenKey)
                 .flatMap(hasToken -> {
                     if (hasToken) {
@@ -44,7 +42,6 @@ public class QueueService {
                                 .build());
                     }
 
-                    // 2. 대기열 존재 여부 체크 (이미 대기 중인 유저)
                     return redisTemplate.opsForZSet()
                             .rank(queueKey, userId.toString())
                             .flatMap(existingRank -> {
@@ -58,22 +55,33 @@ public class QueueService {
                                         .build());
                             })
                             .switchIfEmpty(
-                                    // 3. 신규 진입
                                     Mono.defer(() -> {
-                                        double score = System.currentTimeMillis();
-                                        String heartbeatKey = RedisKeyGenerator.heartbeatKey(scheduleId, userId);
+                                        // 큐 크기 상한 체크
+                                        return redisTemplate.opsForZSet().size(queueKey)
+                                                .defaultIfEmpty(0L)
+                                                .flatMap(queueSize -> {
+                                                    if (queueSize >= queueProperties.getMaxQueueSize()) {
+                                                        return Mono.error(new BusinessException(ErrorCode.QUEUE_FULL));
+                                                    }
 
-                                        return redisTemplate.opsForZSet()
-                                                .add(queueKey, userId.toString(), score)
-                                                .then(redisTemplate.opsForValue().set(heartbeatKey, "alive", HEARTBEAT_TTL))
-                                                .then(getPosition(scheduleId, userId))
-                                                .map(position -> QueueEntryResponse.builder()
-                                                        .scheduleId(scheduleId)
-                                                        .userId(userId)
-                                                        .position(position)
-                                                        .estimatedWaitMinutes(calculateEstimatedWait(position))
-                                                        .message(String.format("%d번째로 대기 중입니다", position))
-                                                        .build());
+                                                    double score = System.currentTimeMillis();
+                                                    String heartbeatKey = RedisKeyGenerator.heartbeatKey(scheduleId, userId);
+                                                    Duration heartbeatTtl = Duration.ofSeconds(queueProperties.getHeartbeatTtlSeconds());
+
+                                                    return redisTemplate.opsForZSet()
+                                                            .add(queueKey, userId.toString(), score)
+                                                            .then(redisTemplate.opsForValue().set(heartbeatKey, "alive", heartbeatTtl))
+                                                            // 스케줄을 active-schedules에 등록 (KEYS 대체)
+                                                            .then(redisTemplate.opsForSet().add(RedisKeyGenerator.activeSchedulesKey(), scheduleId.toString()))
+                                                            .then(getPosition(scheduleId, userId))
+                                                            .map(position -> QueueEntryResponse.builder()
+                                                                    .scheduleId(scheduleId)
+                                                                    .userId(userId)
+                                                                    .position(position)
+                                                                    .estimatedWaitMinutes(calculateEstimatedWait(position))
+                                                                    .message(String.format("%d번째로 대기 중입니다", position))
+                                                                    .build());
+                                                });
                                     })
                             );
                 })
@@ -83,34 +91,35 @@ public class QueueService {
 
     /**
      * 대기열 상태 조회 (Polling용)
+     * 토큰 보유 여부 우선 체크 → 큐 위치 조회
      */
     public Mono<QueueStatusResponse> getQueueStatus(Long scheduleId, Long userId) {
+        String tokenKey = RedisKeyGenerator.tokenKey(userId, scheduleId);
         String queueKey = RedisKeyGenerator.queueKey(scheduleId);
 
-        return redisTemplate.opsForZSet()
-                .rank(queueKey, userId.toString())
-                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.NOT_IN_QUEUE)))
-                .map(rank -> rank + 1)
-                .flatMap(position -> {
-                    if (position <= BATCH_SIZE) {
-                        return queueTokenService.issueToken(userId, scheduleId)
-                                .map(token -> QueueStatusResponse.builder()
+        // 1. 토큰 보유 여부 확인 (이미 입장 처리된 경우)
+        return redisTemplate.opsForValue().get(tokenKey)
+                .flatMap(token -> Mono.just(QueueStatusResponse.builder()
+                        .position(0L)
+                        .status("READY")
+                        .token(token)
+                        .estimatedWaitMinutes(0)
+                        .message("입장 가능합니다")
+                        .build()))
+                .switchIfEmpty(
+                        // 2. 큐 위치 조회
+                        redisTemplate.opsForZSet()
+                                .rank(queueKey, userId.toString())
+                                .map(rank -> rank + 1)
+                                .map(position -> QueueStatusResponse.builder()
                                         .position(position)
-                                        .status("READY")
-                                        .token(token)
-                                        .estimatedWaitMinutes(0)
-                                        .message("입장 가능합니다")
-                                        .build());
-                    }
-
-                    return Mono.just(QueueStatusResponse.builder()
-                            .position(position)
-                            .status("WAITING")
-                            .estimatedWaitMinutes(calculateEstimatedWait(position))
-                            .aheadCount(position - 1)
-                            .message(String.format("앞에 %d명이 대기 중입니다", position - 1))
-                            .build());
-                });
+                                        .status("WAITING")
+                                        .estimatedWaitMinutes(calculateEstimatedWait(position))
+                                        .aheadCount(position - 1)
+                                        .message(String.format("앞에 %d명이 대기 중입니다", position - 1))
+                                        .build())
+                                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.NOT_IN_QUEUE)))
+                );
     }
 
     /**
@@ -119,22 +128,40 @@ public class QueueService {
     public Mono<Boolean> leaveQueue(Long scheduleId, Long userId) {
         String queueKey = RedisKeyGenerator.queueKey(scheduleId);
         String heartbeatKey = RedisKeyGenerator.heartbeatKey(scheduleId, userId);
+        String activeKey = RedisKeyGenerator.activeKey(scheduleId);
 
         return redisTemplate.opsForZSet()
                 .remove(queueKey, userId.toString())
-                .flatMap(removed -> redisTemplate.delete(heartbeatKey).thenReturn(removed > 0))
+                .flatMap(removed -> redisTemplate.opsForZSet().remove(activeKey, userId.toString())
+                        .then(redisTemplate.delete(heartbeatKey))
+                        .thenReturn(removed > 0))
                 .doOnSuccess(success -> log.info("대기열 이탈: userId={}, scheduleId={}, success={}",
                         userId, scheduleId, success));
     }
 
     /**
      * Heartbeat 처리
+     * 큐 대기자: heartbeat 키 TTL 갱신
+     * 활성 유저: active SortedSet score 갱신 (하트비트 타임스탬프)
      */
     public Mono<Boolean> heartbeat(Long scheduleId, Long userId) {
         String heartbeatKey = RedisKeyGenerator.heartbeatKey(scheduleId, userId);
+        String activeKey = RedisKeyGenerator.activeKey(scheduleId);
+        Duration heartbeatTtl = Duration.ofSeconds(queueProperties.getHeartbeatTtlSeconds());
+        double now = System.currentTimeMillis();
 
-        return redisTemplate.opsForValue()
-                .set(heartbeatKey, "alive", HEARTBEAT_TTL);
+        // 큐 heartbeat 키 갱신
+        Mono<Boolean> updateHeartbeat = redisTemplate.opsForValue()
+                .set(heartbeatKey, "alive", heartbeatTtl);
+
+        // active SortedSet에 존재하면 score 갱신 (XX 동작)
+        Mono<Boolean> updateActive = redisTemplate.opsForZSet()
+                .score(activeKey, userId.toString())
+                .flatMap(existingScore ->
+                        redisTemplate.opsForZSet().add(activeKey, userId.toString(), now))
+                .defaultIfEmpty(false);
+
+        return updateHeartbeat.then(updateActive).thenReturn(true);
     }
 
     private Mono<Long> getPosition(Long scheduleId, Long userId) {
@@ -146,9 +173,10 @@ public class QueueService {
     }
 
     private int calculateEstimatedWait(long position) {
-        if (position <= BATCH_SIZE) {
+        int batchSize = queueProperties.getBatchSize();
+        if (position <= batchSize) {
             return 0;
         }
-        return (int) Math.ceil((position - BATCH_SIZE) / 50.0);
+        return (int) Math.ceil((position - batchSize) / 50.0);
     }
 }

--- a/src/main/java/com/fairticket/domain/queue/service/QueueTokenService.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueTokenService.java
@@ -1,5 +1,6 @@
 package com.fairticket.domain.queue.service;
 
+import com.fairticket.domain.queue.config.QueueProperties;
 import com.fairticket.global.util.RedisKeyGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,8 +17,7 @@ import java.util.UUID;
 public class QueueTokenService {
 
     private final ReactiveRedisTemplate<String, String> redisTemplate;
-
-    private static final Duration TOKEN_TTL = Duration.ofSeconds(300);
+    private final QueueProperties queueProperties;
 
     /**
      * 입장 토큰 발급
@@ -25,9 +25,10 @@ public class QueueTokenService {
     public Mono<String> issueToken(Long userId, Long scheduleId) {
         String tokenKey = RedisKeyGenerator.tokenKey(userId, scheduleId);
         String tokenValue = UUID.randomUUID().toString();
+        Duration tokenTtl = Duration.ofSeconds(queueProperties.getTokenTtlSeconds());
 
         return redisTemplate.opsForValue()
-                .set(tokenKey, tokenValue, TOKEN_TTL)
+                .set(tokenKey, tokenValue, tokenTtl)
                 .thenReturn(tokenValue)
                 .doOnSuccess(token -> log.info("입장 토큰 발급: userId={}, scheduleId={}", userId, scheduleId));
     }

--- a/src/main/java/com/fairticket/global/exception/ErrorCode.java
+++ b/src/main/java/com/fairticket/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     NOT_IN_QUEUE(HttpStatus.NOT_FOUND, "Q001", "대기열에 존재하지 않습니다"),
     QUEUE_ENTRY_FAILED(HttpStatus.CONFLICT, "Q002", "대기열 진입에 실패했습니다"),
     INVALID_QUEUE_TOKEN(HttpStatus.FORBIDDEN, "Q003", "유효하지 않은 입장 토큰입니다"),
+    QUEUE_FULL(HttpStatus.SERVICE_UNAVAILABLE, "Q004", "대기열이 가득 찼습니다. 잠시 후 다시 시도해주세요"),
 
     // Concert / Schedule
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "회차 정보를 찾을 수 없습니다"),

--- a/src/main/java/com/fairticket/global/security/JwtProvider.java
+++ b/src/main/java/com/fairticket/global/security/JwtProvider.java
@@ -10,10 +10,6 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
-/**
- * JWT 토큰 생성, 검증, 클레임 추출을 담당하는 컴포넌트.
- * JJWT 라이브러리 기반, HS512 서명 사용.
- */
 @Component
 public class JwtProvider {
 
@@ -30,7 +26,6 @@ public class JwtProvider {
         this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    /** subject=userId, claims에 email/role 포함하여 JWT 생성 */
     public String createToken(Long userId, String email, String role) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + expirationMs);
@@ -49,6 +44,8 @@ public class JwtProvider {
         try {
             Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
             return true;
+        } catch (ExpiredJwtException e) {
+            return false;
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
@@ -66,5 +63,16 @@ public class JwtProvider {
 
     public String getRole(String token) {
         return getClaims(token).get("role", String.class);
+    }
+
+    public long getRemainingExpiration(String token) {
+        try {
+            Claims claims = getClaims(token);
+            long expiration = claims.getExpiration().getTime();
+            long remaining = expiration - System.currentTimeMillis();
+            return Math.max(remaining, 0);
+        } catch (JwtException e) {
+            return 0;
+        }
     }
 }

--- a/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
@@ -68,4 +68,14 @@ public class RedisKeyGenerator {
     public static String lotteryAssignedKey(Long scheduleId) {
         return String.format("lottery-assigned:%d", scheduleId);
     }
+
+    // 활성 스케줄 목록 (KEYS 명령어 대체) - active-schedules
+    public static String activeSchedulesKey() {
+        return "active-schedules";
+    }
+
+    // JWT 블랙리스트 키 (로그아웃 시 토큰 무효화) - blacklist:{token}
+    public static String blacklistKey(String token) {
+        return "blacklist:" + token;
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,6 +66,13 @@ springdoc:
 
 # PortOne 결제 설정 (팀원 C 담당)
 fairticket:
+  queue:
+    batch-size: 100
+    max-active-users: 500
+    max-queue-size: 100000
+    heartbeat-ttl-seconds: 30
+    token-ttl-seconds: 300
+    active-timeout-seconds: 60
   portone:
     api-key: ${PORTONE_API_KEY:test-api-key}
     api-secret: ${PORTONE_API_SECRET:test-api-secret}

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -141,10 +141,10 @@ CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status);
 
 -- 사용자
 INSERT INTO users (email, password, name, phone, role) VALUES
-    ('test1@test.com', 'password123', '테스트유저1', '010-1234-5678', 'USER'),
-    ('test2@test.com', 'password123', '테스트유저2', '010-2345-6789', 'USER'),
-    ('test3@test.com', 'password123', '테스트유저3', '010-3456-7890', 'USER'),
-    ('admin@test.com', 'admin123', '관리자', '010-0000-0000', 'ADMIN')
+    ('test1@test.com', '$2a$10$dXJ3SW6G7P50lGmMQgel6uVktT9bSUuhvEWfXZ/BIi3sMqKYzAG2y', '테스트유저1', '010-1234-5678', 'USER'),
+    ('test2@test.com', '$2a$10$dXJ3SW6G7P50lGmMQgel6uVktT9bSUuhvEWfXZ/BIi3sMqKYzAG2y', '테스트유저2', '010-2345-6789', 'USER'),
+    ('test3@test.com', '$2a$10$dXJ3SW6G7P50lGmMQgel6uVktT9bSUuhvEWfXZ/BIi3sMqKYzAG2y', '테스트유저3', '010-3456-7890', 'USER'),
+    ('admin@test.com', '$2a$10$5c/reWRVIXYM255rCh5orOfA6dFc1FD2axfPSuU79CMmA9uWxhIZW', '관리자', '010-0000-0000', 'ADMIN')
 ON CONFLICT (email) DO NOTHING;
 
 -- 공연
@@ -154,10 +154,11 @@ INSERT INTO concerts (title, artist, venue) VALUES
 ON CONFLICT DO NOTHING;
 
 -- 공연 회차
+-- total_seats = zones 합산: VIP(8×200+11×100=2700) + S(4×100+14×100=1800) + A(6×100=600) = 5100
 INSERT INTO schedules (concert_id, date_time, total_seats, ticket_open_at, ticket_close_at, status) VALUES
-    (1, '2026-03-15 19:00:00', 1000, '2026-02-09 20:00:00', '2026-03-15 18:00:00', 'OPEN'),
-    (2, '2026-04-20 18:00:00', 1500, '2026-02-20 20:00:00', '2026-04-20 17:00:00', 'UPCOMING'),
-    (1, '2026-01-10 19:00:00', 800, '2025-12-01 20:00:00', '2026-01-10 18:00:00', 'CLOSED')
+    (1, '2026-03-15 19:00:00', 5100, '2026-02-09 20:00:00', '2026-03-15 18:00:00', 'OPEN'),
+    (2, '2026-04-20 18:00:00', 5100, '2026-02-20 20:00:00', '2026-04-20 17:00:00', 'UPCOMING'),
+    (1, '2026-01-10 19:00:00', 5100, '2025-12-01 20:00:00', '2026-01-10 18:00:00', 'CLOSED')
 ON CONFLICT DO NOTHING;
 
 -- 등급 설정 (TIMELINE: VIP, S, A)

--- a/src/main/resources/scripts/batch_admit.lua
+++ b/src/main/resources/scripts/batch_admit.lua
@@ -1,0 +1,48 @@
+-- batch_admit.lua
+-- 대기열 → 활성 유저 배치 입장 (원자적 처리)
+--
+-- KEYS[1] = active:{scheduleId}  (SortedSet: score=heartbeat timestamp, member=userId)
+-- KEYS[2] = queue:{scheduleId}   (SortedSet: score=진입 timestamp, member=userId)
+-- ARGV[1] = maxActiveUsers (500)
+-- ARGV[2] = batchSize (100)
+-- ARGV[3] = now (timestamp ms)
+-- ARGV[4] = heartbeatTimeout (60000 ms)
+
+local activeKey = KEYS[1]
+local queueKey = KEYS[2]
+local maxActive = tonumber(ARGV[1])
+local batchSize = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local timeout = tonumber(ARGV[4])
+
+-- 1. 비활성 유저 정리 (하트비트 타임아웃 초과)
+redis.call('ZREMRANGEBYSCORE', activeKey, '-inf', now - timeout)
+
+-- 2. 현재 active 수
+local currentActive = redis.call('ZCARD', activeKey)
+
+-- 3. 여유 슬롯 계산
+local available = maxActive - currentActive
+if available <= 0 then
+    return cjson.encode({admitted = {}, activeCount = currentActive, queueSize = redis.call('ZCARD', queueKey)})
+end
+
+-- 4. 입장 대상 추출 (큐 앞쪽에서)
+local toAdmit = math.min(available, batchSize)
+local candidates = redis.call('ZRANGE', queueKey, 0, toAdmit - 1)
+
+if #candidates == 0 then
+    return cjson.encode({admitted = {}, activeCount = currentActive, queueSize = 0})
+end
+
+-- 5. 큐 → active 이동 (원자적)
+for _, userId in ipairs(candidates) do
+    redis.call('ZADD', activeKey, now, userId)
+end
+redis.call('ZREMRANGEBYRANK', queueKey, 0, #candidates - 1)
+
+return cjson.encode({
+    admitted = candidates,
+    activeCount = currentActive + #candidates,
+    queueSize = redis.call('ZCARD', queueKey)
+})

--- a/src/main/resources/scripts/batch_admit.lua
+++ b/src/main/resources/scripts/batch_admit.lua
@@ -32,7 +32,7 @@ local toAdmit = math.min(available, batchSize)
 local candidates = redis.call('ZRANGE', queueKey, 0, toAdmit - 1)
 
 if #candidates == 0 then
-    return cjson.encode({admitted = {}, activeCount = currentActive, queueSize = 0})
+    return cjson.encode({admitted = {}, activeCount = currentActive, queueSize = redis.call('ZCARD', queueKey)})
 end
 
 -- 5. 큐 → active 이동 (원자적)

--- a/src/main/resources/scripts/queue_enter.lua
+++ b/src/main/resources/scripts/queue_enter.lua
@@ -1,0 +1,21 @@
+-- queue_enter.lua
+-- 큐 크기 상한 체크 + 진입을 원자적으로 처리
+--
+-- KEYS[1] = queue:{scheduleId}  (SortedSet)
+-- ARGV[1] = maxQueueSize
+-- ARGV[2] = userId
+-- ARGV[3] = score (timestamp ms)
+--
+-- return: 1 = 성공, 0 = 큐 가득 참
+
+local queueKey = KEYS[1]
+local maxQueueSize = tonumber(ARGV[1])
+local userId = ARGV[2]
+local score = tonumber(ARGV[3])
+
+if redis.call('ZCARD', queueKey) >= maxQueueSize then
+    return 0
+end
+
+redis.call('ZADD', queueKey, score, userId)
+return 1


### PR DESCRIPTION
 ## 목적

  대기열 시스템 운영 안정성 확보 및 인증 시스템 보완 (10만 동시접속 성능 테스트
  전 필수 개선)

  Closes #26

  ## 변경 사항

  ### 대기열 시스템
  - active 카운터 String(INCR) → Sorted Set + 하트비트 타임스탬프 전환 (유령
  유저 원천 차단)
  - 배치 입장 Lua Script 원자적 처리 (큐→active 이동 레이스 컨디션 제거)
  - Redisson 분산 락으로 스케줄러 중복 실행 방지
  - `KEYS queue:*` → `SMEMBERS active-schedules` 전환 (O(N) 전체 스캔 제거)
  - 스케줄러 에러 핸들링 추가 (장애 시 조용한 무시 → 명시적 로깅)
  - 큐 크기 상한선 추가 (MAX_QUEUE_SIZE 초과 시 503)
  - 설정값 외부화 (QueueProperties + application.yaml)

  ### 인증
  - 로그인/가입 응답에 name, role 필드 추가
  - `POST /api/v1/auth/logout` 추가 (Redis 토큰 블랙리스트)
  - JwtAuthenticationFilter에 블랙리스트 체크 추가
  - JwtProvider에 getRemainingExpiration() 추가

  ### 데이터
  - init.sql total_seats를 zones 합산값(5100)으로 수정
  - init.sql 비밀번호 BCrypt 해싱 적용

  ## 신규 파일
  - `batch_admit.lua` — 배치 입장 Lua Script
  - `QueueProperties.java` — 대기열 설정값 클래스

  ## 테스트
  - [x] `gradle build` 성공
  - [x] 회원가입 → name/role 포함 응답 확인
  - [x] 로그인 → JWT 발급 확인
  - [x] 대기열 진입 → 배치 입장 → 토큰 발급 확인
  - [x] 하트비트 정상 동작
  - [x] 대기열 이탈 정상 동작
  - [x] 로그아웃 → 블랙리스트 등록 → 이후 401 확인
  - [x] 토큰 없이 접근 → 401 확인
  
