### PR TITLE
feat: Redis 좌석 풀 초기화 API 추가

### DIFF
--- a/src/main/java/com/fairticket/domain/seat/controller/SeatPoolController.java
+++ b/src/main/java/com/fairticket/domain/seat/controller/SeatPoolController.java
@@ -1,0 +1,27 @@
+package com.fairticket.domain.seat.controller;
+
+import com.fairticket.domain.seat.service.SeatPoolService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "Seat Pool", description = "좌석 풀 관리 API (관리자용)")
+@RestController
+@RequestMapping("/api/v1/admin/seats")
+@RequiredArgsConstructor
+public class SeatPoolController {
+
+    private final SeatPoolService seatPoolService;
+
+    @PostMapping("/{scheduleId}/initialize")
+    public Mono<ResponseEntity<Void>> initializeSeatPools(
+            @Parameter(required = true)
+            @PathVariable Long scheduleId) {
+        return seatPoolService.initializeSeatPools(scheduleId)
+                .then(Mono.just(ResponseEntity.ok().build()));
+    }
+}

--- a/src/main/java/com/fairticket/domain/seat/service/SeatPoolService.java
+++ b/src/main/java/com/fairticket/domain/seat/service/SeatPoolService.java
@@ -47,14 +47,17 @@ public class SeatPoolService {
 
     /**
      * 지정한 구역·좌석 번호 목록으로 Redis 풀 초기화
+     * 기존 데이터를 삭제하고 새로 초기화합니다.
      */
     public Mono<Void> initializeSeatPoolWithNumbers(Long scheduleId, String zone, List<String> seatNumbers) {
         if (seatNumbers.isEmpty()) {
             return Mono.empty();
         }
         String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
-        return redisTemplate.opsForSet()
-                .add(poolKey, seatNumbers.toArray(new String[0]))
+        // 기존 키 삭제 후 새로 추가
+        return redisTemplate.delete(poolKey)
+                .then(redisTemplate.opsForSet()
+                        .add(poolKey, seatNumbers.toArray(new String[0])))
                 .doOnSuccess(c -> log.info("좌석 풀 초기화: scheduleId={}, zone={}, count={}", 
                         scheduleId, zone, seatNumbers.size()))
                 .then();


### PR DESCRIPTION
## Summary

라이브 결제 테스트를 위해 Redis 좌석 풀을 초기화할 수 있는 관리자용 API가 없어 라이브 예매 API가 동작하지 않는 문제를 해결했습니다.

- `SeatPoolService.initializeSeatPools()` 메서드는 존재하지만 호출하는 API가 없음
- Redis 좌석 풀이 비어있어 `LiveTrackService`의 잔여 좌석 체크가 실패하여 라이브 예매 API가 동작하지 않음

## Changes

### 1. 관리자용 좌석 풀 초기화 API 추가
- **파일**: `SeatPoolController.java` (신규 생성)
- **엔드포인트**: `POST /api/v1/admin/seats/{scheduleId}/initialize`
- **기능**: 지정한 회차의 Redis 좌석 풀을 `seats` 테이블 기준으로 초기화
- **인증**: JWT 토큰 필요 (현재는 인증만 필요, 추후 관리자 권한 체크 추가 가능)

### 2. 좌석 풀 초기화 로직 개선
- **파일**: `SeatPoolService.java`
- **변경 내용**: `initializeSeatPoolWithNumbers()` 메서드에서 기존 Redis 키를 삭제한 후 새로 추가하도록 수정
- **이유**: 기존 데이터가 남아있을 경우 중복되거나 불일치가 발생할 수 있어 완전한 초기화를 보장

```java
// 변경 전: 기존 Set에 추가만 함
return redisTemplate.opsForSet()
    .add(poolKey, seatNumbers.toArray(new String[0]))

// 변경 후: 기존 키 삭제 후 새로 추가
return redisTemplate.delete(poolKey)
    .then(redisTemplate.opsForSet()
        .add(poolKey, seatNumbers.toArray(new String[0])))
```

## API Test

### 테스트 환경
- 서버: `http://localhost:8080`
- 테스트 회차 ID: `1`

### 테스트 시나리오
**요청:**
```bash
curl -X POST "http://localhost:8080/api/v1/admin/seats/1/initialize" \
  -H "Authorization: Bearer {JWT_TOKEN}" \
  -H "Content-Type: application/json" \
  -i
```

**응답:**
```
HTTP/1.1 200 OK
X-RateLimit-Remaining: 57
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 0
Referrer-Policy: no-referrer
content-length: 0
```

### 테스트 결과
**성공**: HTTP 200 OK

- API 정상 호출 확인
- 좌석 풀 초기화 로직 실행 확인
- 응답 본문: 빈 응답 (정상, `content-length: 0`)

## 관련 Issue
#31 
