### PR TITLE
feat: 프론트 연동 결제 Webhook API 완성 및 에러 처리 개선

### DIFF
--- a/src/main/java/com/fairticket/domain/payment/dto/WebhookRequest.java
+++ b/src/main/java/com/fairticket/domain/payment/dto/WebhookRequest.java
@@ -1,0 +1,11 @@
+package com.fairticket.domain.payment.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WebhookRequest {
+    private String impUid;       // PortOne 결제 고유번호
+    private String merchantUid;  // 우리 시스템 주문번호
+}

--- a/src/main/java/com/fairticket/domain/payment/repository/PaymentQueryRepository.java
+++ b/src/main/java/com/fairticket/domain/payment/repository/PaymentQueryRepository.java
@@ -1,0 +1,44 @@
+package com.fairticket.domain.payment.repository;
+
+import com.fairticket.domain.payment.entity.Payment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+import java.time.LocalDateTime;
+
+/**
+ * R2DBC는 JOIN을 자동 지원하지 않으므로 DatabaseClient로 직접 쿼리
+ * Payment → Reservation (1:1) → User
+ */
+@Repository
+@RequiredArgsConstructor
+public class PaymentQueryRepository {
+
+    private final DatabaseClient databaseClient;
+
+    // userId 기준 결제 목록 조회 (Payment JOIN Reservation)
+    public Flux<Payment> findByUserId(Long userId) {
+        return databaseClient.sql("""
+                SELECT p.*
+                FROM payments p
+                JOIN reservations r ON p.reservation_id = r.id
+                WHERE r.user_id = :userId
+                ORDER BY p.created_at DESC
+                """)
+                .bind("userId", userId)
+                .map((row, metadata) -> Payment.builder()
+                        .id(row.get("id", Long.class))
+                        .reservationId(row.get("reservation_id", Long.class))
+                        .merchantUid(row.get("merchant_uid", String.class))
+                        .impUid(row.get("imp_uid", String.class))
+                        .amount(row.get("amount", Integer.class))
+                        .status(row.get("status", String.class))
+                        .paidAt(row.get("paid_at", LocalDateTime.class))
+                        .createdAt(row.get("created_at", LocalDateTime.class))
+                        .updatedAt(row.get("updated_at", LocalDateTime.class))
+                        .build())
+                .all();
+    }
+}

--- a/src/main/java/com/fairticket/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/fairticket/domain/payment/repository/PaymentRepository.java
@@ -13,4 +13,6 @@ public interface PaymentRepository extends ReactiveCrudRepository<Payment, Long>
 
     Flux<Payment> findByStatus(String status);
 
+    // userId 기준 조회는 Payment→Reservation JOIN 필요
+    // → PaymentQueryRepository 사용
 }


### PR DESCRIPTION
## Summary
프론트엔드에서 impUid, merchantUid만 전달하면 결제 완료부터 트랙별 후속 처리까지 자동으로 동작하는 Webhook API 완성 및 관련 에러 처리 개선

## Changes
- `PaymentController`: `/complete` → `/webhook` 변경, `GET /my` 내 결제 목록 조회 추가
- `PaymentService`: `completePayment()` `WebhookRequest` 기반으로 변경, 중복 결제 방지(`PAYMENT_ALREADY_COMPLETED`) 추가,
  `getMyPayments()` 추가
- `WebhookRequest`: impUid, merchantUid 수신 DTO 추가 (신규)
- `PaymentRepository`: `findByUserId` 제거
- `PaymentQueryRepository`: `Payment JOIN Reservation` JOIN 쿼리로 userId 기준 결제 목록 조회 (신규)
- `PortOneClient`: API 실패 시 500 대신 의미있는 에러 메시지 반환, `testMode` 플래그 제거
- `SecurityConfig`: `POST /api/v1/payment/webhook` 인증 제외 추가

## API
| Method | URL | 설명 |
|--------|-----|------|
| POST | `/api/v1/payment/webhook` | PortOne Webhook 수신 (인증 불필요) |
| GET | `/api/v1/payment/my` | 내 결제 목록 조회 |

## Closes
#28