### PR TITLE
fix: 대기열·인증 버그 3건 수정

### DIFF
--- a/src/main/java/com/fairticket/domain/queue/service/QueueScheduler.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueScheduler.java
@@ -90,8 +90,13 @@ public class QueueScheduler {
                     try {
                         Map<String, Object> parsed = objectMapper.readValue(
                                 result, new TypeReference<Map<String, Object>>() {});
+                        // Lua cjson.encode({}) → JSON "{}" (object) → LinkedHashMap
+                        // Lua cjson.encode({"a","b"}) → JSON ["a","b"] (array) → List
+                        Object admittedRaw = parsed.get("admitted");
                         @SuppressWarnings("unchecked")
-                        List<String> admitted = (List<String>) parsed.get("admitted");
+                        List<String> admitted = (admittedRaw instanceof List)
+                                ? (List<String>) admittedRaw
+                                : List.of();
                         int activeCount = ((Number) parsed.get("activeCount")).intValue();
                         int queueSize = ((Number) parsed.get("queueSize")).intValue();
 

--- a/src/main/java/com/fairticket/global/config/SecurityConfig.java
+++ b/src/main/java/com/fairticket/global/config/SecurityConfig.java
@@ -32,6 +32,11 @@ public class SecurityConfig {
                 .authorizeExchange(exchanges -> exchanges
                         // 인증 불필요
                         .pathMatchers(HttpMethod.POST, "/api/v1/auth/**").permitAll()
+                        // 공연·스케줄 조회 (비인증 허용)
+                        .pathMatchers(HttpMethod.GET, "/api/v1/concerts/**").permitAll()
+                        .pathMatchers(HttpMethod.GET, "/api/v1/schedules/**").permitAll()
+                        // 결제 Webhook (PortOne 서버→서버 호출)
+                        .pathMatchers(HttpMethod.POST, "/api/v1/payment/webhook").permitAll()
                         // Actuator
                         .pathMatchers("/actuator/**").permitAll()
                         // Swagger (WebFlux)


### PR DESCRIPTION
## Summary
  develop 머지 후 API 테스트에서 발견된 버그 3건 수정 + init.sql 테스트 데이터
  보강

  ## Changes

  ### 버그 수정
  - **QueueScheduler**: `batch_admit.lua`가 빈 배열 반환 시 `cjson.encode({})`가
   JSON object(`{}`)로 인코딩되어 `LinkedHashMap`→`List` ClassCastException 발생
   → instanceof 분기 처리
  - **SecurityConfig**: `GET /concerts/**`, `GET /schedules/**` permitAll
  누락으로 비인증 조회 불가 → 추가. `POST /payment/webhook` permitAll도 추가
  - **init.sql**: 기존 유저 비밀번호가 평문으로 남아있을 때 갱신되지 않는 문제 →
   `ON CONFLICT DO UPDATE` + bcrypt 해시 재생성 (test1~3: `password`, admin:
  `admin`)

  ## Closes
  #38
