### PR TITLE
feat: 로터리 트랙 대기열 토큰 검증 연동

### DIFF
--- a/src/main/java/com/fairticket/domain/reservation/controller/LotteryTrackController.java
+++ b/src/main/java/com/fairticket/domain/reservation/controller/LotteryTrackController.java
@@ -21,8 +21,9 @@ public class LotteryTrackController {
     @PostMapping("/{scheduleId}")
     public Mono<ResponseEntity<ReservationResponse>> createReservation(
             @RequestBody LotteryReservationRequest request,
-            @RequestHeader("X-User-Id") Long userId) {
-        return lotteryTrackService.createLotteryReservation(request, userId)
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestHeader("X-Queue-Token") String queueToken) {
+        return lotteryTrackService.createLotteryReservation(request, userId, queueToken)
                 .map(ResponseEntity::ok);
     }
 


### PR DESCRIPTION
## Summary
  - 로터리 트랙 예약(`POST /lottery/{scheduleId}`) 시 대기열 토큰 검증 추가
  - 라이브 트랙과 동일하게 대기열을 거쳐야만 예약 가능하도록 변경
  - 토큰 1회 소비로 재사용 차단

  ## Changes (2 files)
  - **LotteryTrackController**: `X-Queue-Token` 헤더 파라미터 추가
  - **LotteryTrackService**: `QueueTokenService` 의존성 추가, 기존 로직 앞에
  `validateToken` → `consumeToken` 체인 삽입

  ## Flow
  POST /queue/{scheduleId}/enter → 대기열 진입
  GET /queue/{scheduleId}/status (폴링) → token 수신
  POST /lottery/{scheduleId} (X-Queue-Token 헤더) → 예약 생성

