### PR TITLE
feat: 대기열 시스템 버그 수정 및 로터리 트랙 대기열 연동

### DIFF
--- a/src/main/java/com/fairticket/domain/queue/service/QueueScheduler.java
+++ b/src/main/java/com/fairticket/domain/queue/service/QueueScheduler.java
@@ -90,8 +90,13 @@ public class QueueScheduler {
                     try {
                         Map<String, Object> parsed = objectMapper.readValue(
                                 result, new TypeReference<Map<String, Object>>() {});
+                        // Lua cjson.encode({}) → JSON "{}" (object) → LinkedHashMap
+                        // Lua cjson.encode({"a","b"}) → JSON ["a","b"] (array) → List
+                        Object admittedRaw = parsed.get("admitted");
                         @SuppressWarnings("unchecked")
-                        List<String> admitted = (List<String>) parsed.get("admitted");
+                        List<String> admitted = (admittedRaw instanceof List)
+                                ? (List<String>) admittedRaw
+                                : List.of();
                         int activeCount = ((Number) parsed.get("activeCount")).intValue();
                         int queueSize = ((Number) parsed.get("queueSize")).intValue();
 

--- a/src/main/java/com/fairticket/domain/reservation/controller/LotteryTrackController.java
+++ b/src/main/java/com/fairticket/domain/reservation/controller/LotteryTrackController.java
@@ -21,8 +21,9 @@ public class LotteryTrackController {
     @PostMapping("/{scheduleId}")
     public Mono<ResponseEntity<ReservationResponse>> createReservation(
             @RequestBody LotteryReservationRequest request,
-            @RequestHeader("X-User-Id") Long userId) {
-        return lotteryTrackService.createLotteryReservation(request, userId)
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestHeader("X-Queue-Token") String queueToken) {
+        return lotteryTrackService.createLotteryReservation(request, userId, queueToken)
                 .map(ResponseEntity::ok);
     }
 

--- a/src/main/java/com/fairticket/global/config/SecurityConfig.java
+++ b/src/main/java/com/fairticket/global/config/SecurityConfig.java
@@ -32,6 +32,11 @@ public class SecurityConfig {
                 .authorizeExchange(exchanges -> exchanges
                         // 인증 불필요
                         .pathMatchers(HttpMethod.POST, "/api/v1/auth/**").permitAll()
+                        // 공연·스케줄 조회 (비인증 허용)
+                        .pathMatchers(HttpMethod.GET, "/api/v1/concerts/**").permitAll()
+                        .pathMatchers(HttpMethod.GET, "/api/v1/schedules/**").permitAll()
+                        // 결제 Webhook (PortOne 서버→서버 호출)
+                        .pathMatchers(HttpMethod.POST, "/api/v1/payment/webhook").permitAll()
                         // Actuator
                         .pathMatchers("/actuator/**").permitAll()
                         // Swagger (WebFlux)


### PR DESCRIPTION
## Summary
  - 대기열·인증 버그 3건 수정
  - 로터리 트랙 예약 시 대기열 토큰 검증 연동 (10만 동시접속 대비)

  ## Changes
  ### 버그 수정
  - **QueueScheduler**: Lua `cjson.encode({})` → `"{}"` 파싱 시
  ClassCastException 수정
  - **SecurityConfig**: 공개 엔드포인트 누락 추가 (concerts/schedules GET,
  payment webhook POST)
  - **init.sql**: 시드 데이터 보강

  ### 로터리 대기열 연동
  - **LotteryTrackController**: `X-Queue-Token` 헤더 파라미터 추가
  - **LotteryTrackService**: `QueueTokenService` 의존성 추가, 예약 로직 앞에
  `validateToken` → `consumeToken` 체인 삽입

  ## Flow
  POST /queue/{scheduleId}/enter → 대기열 진입
  GET /queue/{scheduleId}/status (폴링) → token 수신
  POST /lottery/{scheduleId} (X-Queue-Token 헤더) → 예약 생성


