### PR TITLE
feat: 공연 조회 API 구현

### DIFF
--- a/src/main/java/com/fairticket/domain/concert/controller/ConcertController.java
+++ b/src/main/java/com/fairticket/domain/concert/controller/ConcertController.java
@@ -1,0 +1,27 @@
+package com.fairticket.domain.concert.controller;
+
+import com.fairticket.domain.concert.dto.ConcertResponse;
+import com.fairticket.domain.concert.service.ConcertService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/v1/concerts")
+@RequiredArgsConstructor
+public class ConcertController {
+
+    private final ConcertService concertService;
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public Flux<ConcertResponse> getConcerts() {
+        return concertService.getConcerts();
+    }
+
+    @GetMapping(value = "/{concertId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ConcertResponse> getConcertById(@PathVariable Long concertId) {
+        return concertService.getConcertById(concertId);
+    }
+}

--- a/src/main/java/com/fairticket/domain/concert/dto/ConcertResponse.java
+++ b/src/main/java/com/fairticket/domain/concert/dto/ConcertResponse.java
@@ -1,0 +1,24 @@
+package com.fairticket.domain.concert.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConcertResponse {
+
+    private Long id;
+    private String title;
+    private String artist;
+    private String venue;
+    private String saleStatus;   // "on-sale" / "coming-soon" / "sold-out"
+    private String saleDate;     // UPCOMING일 때만, ISO-8601 (null 가능)
+    private List<ScheduleResponse> dates;
+    private List<GradeDetailResponse> grades;
+}

--- a/src/main/java/com/fairticket/domain/concert/dto/GradeDetailResponse.java
+++ b/src/main/java/com/fairticket/domain/concert/dto/GradeDetailResponse.java
@@ -1,0 +1,19 @@
+package com.fairticket.domain.concert.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GradeDetailResponse {
+
+    private String id;           // grade 소문자 (예: "vip", "s", "a")
+    private String label;        // grade 원본 (예: "VIP", "S", "A")
+    private int price;
+    private int totalSeats;      // zones에서 해당 grade의 seat_count 합산
+    private int availableSeats; // seats에서 해당 grade의 status='AVAILABLE' 카운트
+}

--- a/src/main/java/com/fairticket/domain/concert/dto/ScheduleResponse.java
+++ b/src/main/java/com/fairticket/domain/concert/dto/ScheduleResponse.java
@@ -1,0 +1,19 @@
+package com.fairticket.domain.concert.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleResponse {
+
+    private Long id;
+    private String date;   // yyyy-MM-dd
+    private String time;  // HH:mm
+    private String venue;
+    private boolean available;  // schedules.status == "OPEN"
+}

--- a/src/main/java/com/fairticket/domain/concert/repository/ConcertRepository.java
+++ b/src/main/java/com/fairticket/domain/concert/repository/ConcertRepository.java
@@ -1,0 +1,7 @@
+package com.fairticket.domain.concert.repository;
+
+import com.fairticket.domain.concert.entity.Concert;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface ConcertRepository extends ReactiveCrudRepository<Concert, Long> {
+}

--- a/src/main/java/com/fairticket/domain/concert/repository/ScheduleRepository.java
+++ b/src/main/java/com/fairticket/domain/concert/repository/ScheduleRepository.java
@@ -8,6 +8,8 @@ import java.time.LocalDateTime;
 
 public interface ScheduleRepository extends ReactiveCrudRepository<Schedule, Long> {
 
+    Flux<Schedule> findByConcertId(Long concertId);
+
     // 티켓 오픈 시각이 주어진 시각 이전(이하)인 회차만 조회. 스케줄러에서 활성 회차만 처리할 때 사용 
     Flux<Schedule> findByTicketOpenAtLessThanEqual(LocalDateTime time);
 }

--- a/src/main/java/com/fairticket/domain/concert/service/ConcertService.java
+++ b/src/main/java/com/fairticket/domain/concert/service/ConcertService.java
@@ -1,0 +1,165 @@
+package com.fairticket.domain.concert.service;
+
+import com.fairticket.domain.concert.dto.ConcertResponse;
+import com.fairticket.domain.concert.dto.GradeDetailResponse;
+import com.fairticket.domain.concert.dto.ScheduleResponse;
+import com.fairticket.domain.concert.entity.Concert;
+import com.fairticket.domain.concert.entity.Grade;
+import com.fairticket.domain.concert.entity.Schedule;
+import com.fairticket.domain.concert.entity.ScheduleStatus;
+import com.fairticket.domain.concert.repository.ConcertRepository;
+import com.fairticket.domain.concert.repository.GradeRepository;
+import com.fairticket.domain.concert.repository.ScheduleRepository;
+import com.fairticket.domain.concert.entity.Zone;
+import com.fairticket.domain.concert.repository.ZoneRepository;
+import com.fairticket.domain.seat.dto.GradeSeatCount;
+import com.fairticket.domain.seat.repository.SeatRepository;
+import com.fairticket.global.exception.BusinessException;
+import com.fairticket.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ConcertService {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm");
+    private static final DateTimeFormatter ISO_DATE_TIME = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    private final ConcertRepository concertRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final GradeRepository gradeRepository;
+    private final ZoneRepository zoneRepository;
+    private final SeatRepository seatRepository;
+
+    public Flux<ConcertResponse> getConcerts() {
+        return concertRepository.findAll()
+                .flatMap(this::toConcertResponse);
+    }
+
+    public Mono<ConcertResponse> getConcertById(Long concertId) {
+        return concertRepository.findById(concertId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.CONCERT_NOT_FOUND)))
+                .flatMap(this::toConcertResponse);
+    }
+
+    private Mono<ConcertResponse> toConcertResponse(Concert concert) {
+        return scheduleRepository.findByConcertId(concert.getId())
+                .collectList()
+                .flatMap(schedules -> buildResponse(concert, schedules));
+    }
+
+    private Mono<ConcertResponse> buildResponse(Concert concert, List<Schedule> schedules) {
+        String saleStatus = deriveSaleStatus(schedules);
+        String saleDate = deriveSaleDate(schedules);
+        List<ScheduleResponse> dates = schedules.stream()
+                .map(s -> ScheduleResponse.builder()
+                        .id(s.getId())
+                        .date(s.getDateTime().format(DATE_FORMAT))
+                        .time(s.getDateTime().format(TIME_FORMAT))
+                        .venue(concert.getVenue())
+                        .available(ScheduleStatus.OPEN.name().equals(s.getStatus()))
+                        .build())
+                .collect(Collectors.toList());
+
+        if (schedules.isEmpty()) {
+            return Mono.just(ConcertResponse.builder()
+                    .id(concert.getId())
+                    .title(concert.getTitle())
+                    .artist(concert.getArtist())
+                    .venue(concert.getVenue())
+                    .saleStatus("sold-out")
+                    .saleDate(null)
+                    .dates(List.of())
+                    .grades(List.of())
+                    .build());
+        }
+
+        Schedule refSchedule = chooseReferenceScheduleForGrades(schedules);
+        return buildGrades(refSchedule)
+                .map(grades -> ConcertResponse.builder()
+                        .id(concert.getId())
+                        .title(concert.getTitle())
+                        .artist(concert.getArtist())
+                        .venue(concert.getVenue())
+                        .saleStatus(saleStatus)
+                        .saleDate(saleDate)
+                        .dates(dates)
+                        .grades(grades)
+                        .build());
+    }
+
+    private String deriveSaleStatus(List<Schedule> schedules) {
+        if (schedules.isEmpty()) return "sold-out";
+        boolean anyOpen = schedules.stream().anyMatch(s -> ScheduleStatus.OPEN.name().equals(s.getStatus()));
+        boolean allUpcoming = schedules.stream().allMatch(s -> ScheduleStatus.UPCOMING.name().equals(s.getStatus()));
+        boolean allClosed = schedules.stream().allMatch(s -> ScheduleStatus.CLOSED.name().equals(s.getStatus()));
+        if (anyOpen) return "on-sale";
+        if (allUpcoming) return "coming-soon";
+        if (allClosed) return "sold-out";
+        return "on-sale"; // mixed
+    }
+
+    private String deriveSaleDate(List<Schedule> schedules) {
+        return schedules.stream()
+                .filter(s -> ScheduleStatus.UPCOMING.name().equals(s.getStatus()))
+                .findFirst()
+                .map(s -> s.getTicketOpenAt() != null ? s.getTicketOpenAt().format(ISO_DATE_TIME) : null)
+                .orElse(null);
+    }
+
+    private Schedule chooseReferenceScheduleForGrades(List<Schedule> schedules) {
+        return schedules.stream()
+                .filter(s -> ScheduleStatus.OPEN.name().equals(s.getStatus()))
+                .findFirst()
+                .or(() -> schedules.stream()
+                        .filter(s -> ScheduleStatus.UPCOMING.name().equals(s.getStatus()))
+                        .findFirst())
+                .orElse(schedules.get(0));
+    }
+
+    private Mono<List<GradeDetailResponse>> buildGrades(Schedule refSchedule) {
+        Mono<List<Grade>> gradesMono =
+                gradeRepository.findByScheduleId(refSchedule.getId()).collectList();
+        Mono<Map<String, Integer>> totalByGrade = zoneRepository.findByScheduleId(refSchedule.getId())
+                .collectList()
+                .map(zones -> zones.stream()
+                        .collect(Collectors.groupingBy(Zone::getGrade,
+                                Collectors.summingInt(z -> z.getSeatCount() != null ? z.getSeatCount() : 0))));
+        Mono<Map<String, Long>> availableByGrade = seatRepository
+                .findAvailableSeatCountByScheduleIdGroupByGrade(refSchedule.getId())
+                .collectList()
+                .map(list -> list.stream()
+                        .collect(Collectors.toMap(GradeSeatCount::getGrade, GradeSeatCount::getCount)));
+
+        return Mono.zip(gradesMono, totalByGrade, availableByGrade)
+                .map(tuple -> {
+                    List<Grade> grades = tuple.getT1();
+                    Map<String, Integer> totalMap = tuple.getT2();
+                    Map<String, Long> availableMap = tuple.getT3();
+                    List<GradeDetailResponse> result = new ArrayList<>();
+                    for (Grade g : grades) {
+                        String grade = g.getGrade();
+                        int totalSeats = totalMap.getOrDefault(grade, 0);
+                        int availableSeats = Math.toIntExact(availableMap.getOrDefault(grade, 0L));
+                        result.add(GradeDetailResponse.builder()
+                                .id(grade != null ? grade.toLowerCase() : "")
+                                .label(grade != null ? grade : "")
+                                .price(g.getPrice() != null ? g.getPrice() : 0)
+                                .totalSeats(totalSeats)
+                                .availableSeats(availableSeats)
+                                .build());
+                    }
+                    return result;
+                });
+    }
+}

--- a/src/main/java/com/fairticket/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/fairticket/domain/seat/repository/SeatRepository.java
@@ -36,4 +36,8 @@ public interface SeatRepository extends ReactiveCrudRepository<Seat, Long> {
     // 등급별 좌석 수 집계 (hasLotteryQuotaReached 최적화용)
     @Query("SELECT grade, COUNT(*) as count FROM seats WHERE schedule_id = :scheduleId GROUP BY grade")
     Flux<GradeSeatCount> findSeatCountByScheduleIdGroupByGrade(Long scheduleId);
+
+    // 등급별 잔여석 수 집계 (공연 조회 API용)
+    @Query("SELECT grade, COUNT(*) as count FROM seats WHERE schedule_id = :scheduleId AND status = 'AVAILABLE' GROUP BY grade")
+    Flux<GradeSeatCount> findAvailableSeatCountByScheduleIdGroupByGrade(@Param("scheduleId") Long scheduleId);
 }

--- a/src/main/java/com/fairticket/global/exception/ErrorCode.java
+++ b/src/main/java/com/fairticket/global/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     QUEUE_FULL(HttpStatus.SERVICE_UNAVAILABLE, "Q004", "대기열이 가득 찼습니다. 잠시 후 다시 시도해주세요"),
 
     // Concert / Schedule
+    CONCERT_NOT_FOUND(HttpStatus.NOT_FOUND, "CO001", "공연을 찾을 수 없습니다"),
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "회차 정보를 찾을 수 없습니다"),
 
     // Reservation


### PR DESCRIPTION
## 개요

FE 공연 목록/상세 페이지의 mock 제거 및 실제 API 연동을 위해 공연 조회 API를 구현했습니다.  
`GET /api/v1/concerts`, `GET /api/v1/concerts/{concertId}` 두 엔드포인트를 추가하고, 기존 `concerts`, `schedules`, `grades`, `zones`, `seats` 엔티티/테이블을 활용한 읽기 전용 Controller·Service·DTO를 추가했습니다. 

## 변경 사항

### 신규 파일

| 파일 | 설명 |
|------|------|
| `domain/concert/repository/ConcertRepository.java` | `ReactiveCrudRepository<Concert, Long>` 상속 |
| `domain/concert/service/ConcertService.java` | 공연 목록/상세 조회, saleStatus·잔여석·grades 계산 로직 |
| `domain/concert/controller/ConcertController.java` | `GET /api/v1/concerts`, `GET /api/v1/concerts/{concertId}` 핸들러 |
| `domain/concert/dto/ConcertResponse.java` | 공연 응답 DTO (id, title, artist, venue, saleStatus, saleDate, dates, grades) |
| `domain/concert/dto/ScheduleResponse.java` | 회차 응답 DTO (id, date, time, venue, available) |
| `domain/concert/dto/GradeDetailResponse.java` | 등급별 상세 DTO (id, label, price, totalSeats, availableSeats) |

### 수정 파일

| 파일 | 내용 |
|------|------|
| `ScheduleRepository.java` | `Flux<Schedule> findByConcertId(Long concertId)` 추가 |
| `SeatRepository.java` | `findAvailableSeatCountByScheduleIdGroupByGrade(Long scheduleId)` 추가 (등급별 잔여석 집계) |
| `ErrorCode.java` | `CONCERT_NOT_FOUND(HttpStatus.NOT_FOUND, "CO001", "공연을 찾을 수 없습니다")` 추가 |

### 비즈니스 로직 요약

- **saleStatus**: schedule 중 하나라도 `OPEN` → `"on-sale"`, 전부 `UPCOMING` → `"coming-soon"`, 전부 `CLOSED` → `"sold-out"`
- **totalSeats**: zones 테이블에서 `schedule_id + grade` 기준 `seat_count` 합산
- **availableSeats**: seats 테이블에서 `schedule_id + grade` 기준 `status = 'AVAILABLE'` 카운트
- **grades**: 첫 번째 OPEN 상태 schedule 기준 (없으면 첫 UPCOMING, 그도 없으면 첫 schedule)
- **인증**: `SecurityConfig`에 이미 `GET /api/v1/concerts/**` permitAll 설정됨

## API

| 메서드 | 경로 | 설명 | 응답 |
|--------|------|------|------|
| GET | `/api/v1/concerts` | 공연 목록 조회 | `Flux<ConcertResponse>` |
| GET | `/api/v1/concerts/{concertId}` | 공연 상세 조회 (없으면 404) | `Mono<ConcertResponse>` |

## 관련 이슈
#43