### PR TITLE
feat: Kafka Producer/Consumer 기본 연동 세팅

### DIFF
--- a/src/main/java/com/fairticket/domain/payment/dto/package-info.java
+++ b/src/main/java/com/fairticket/domain/payment/dto/package-info.java
@@ -1,0 +1,1 @@
+package com.fairticket.domain.payment.dto;

--- a/src/main/java/com/fairticket/domain/payment/dto/package-info.java
+++ b/src/main/java/com/fairticket/domain/payment/dto/package-info.java
@@ -1,1 +1,0 @@
-package com.fairticket.domain.payment.dto;

--- a/src/main/java/com/fairticket/domain/payment/service/PaymentEventProducer.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PaymentEventProducer.java
@@ -1,0 +1,56 @@
+package com.fairticket.domain.payment.service;
+
+import com.fairticket.global.config.KafkaTopics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentEventProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    // 결제 완료 이벤트 발행 → seat-assignment 토픽
+    // key: reservationId (같은 예약의 이벤트 순서 보장)
+    public Mono<Void> sendSeatAssignmentEvent(Long reservationId, Long userId, Long scheduleId, String grade) {
+        String message = String.format(
+                "{\"reservationId\":%d,\"userId\":%d,\"scheduleId\":%d,\"grade\":\"%s\"}",
+                reservationId, userId, scheduleId, grade
+        );
+
+        return Mono.fromCallable(() -> kafkaTemplate.send(
+                        KafkaTopics.SEAT_ASSIGNMENT,
+                        String.valueOf(reservationId),
+                        message))
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(result -> log.info("[Kafka] seat-assignment 발행: reservationId={}, grade={}",
+                        reservationId, grade))
+                .doOnError(e -> log.error("[Kafka] seat-assignment 발행 실패: reservationId={}, error={}",
+                        reservationId, e.getMessage()))
+                .then();
+    }
+
+    // 환불 이벤트 발행 → refund 토픽
+    public Mono<Void> sendRefundEvent(Long paymentId, Long reservationId, int amount, String reason) {
+        String message = String.format(
+                "{\"paymentId\":%d,\"reservationId\":%d,\"amount\":%d,\"reason\":\"%s\"}",
+                paymentId, reservationId, amount, reason
+        );
+
+        return Mono.fromCallable(() -> kafkaTemplate.send(
+                        KafkaTopics.REFUND,
+                        String.valueOf(paymentId),
+                        message))
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(result -> log.info("[Kafka] refund 발행: paymentId={}, amount={}",
+                        paymentId, amount))
+                .doOnError(e -> log.error("[Kafka] refund 발행 실패: paymentId={}, error={}",
+                        paymentId, e.getMessage()))
+                .then();
+    }
+}

--- a/src/main/java/com/fairticket/domain/payment/service/RefundConsumer.java
+++ b/src/main/java/com/fairticket/domain/payment/service/RefundConsumer.java
@@ -1,0 +1,32 @@
+package com.fairticket.domain.payment.service;
+
+import com.fairticket.global.config.KafkaTopics;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * refund 토픽 Consumer 뼈대
+ * 실제 환불 처리 로직 연결은 추후 이슈에서 진행
+ */
+@Slf4j
+@Component
+public class RefundConsumer {
+
+    @KafkaListener(
+            topics = KafkaTopics.REFUND,
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void handleRefund(
+            @Payload String message,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.OFFSET) long offset) {
+        log.info("[Kafka] refund 수신: topic={}, offset={}, message={}",
+                topic, offset, message);
+
+        // TODO: 실제 환불 처리 로직 연결 (추후 이슈)
+    }
+}

--- a/src/main/java/com/fairticket/domain/reservation/service/SeatAssignmentConsumer.java
+++ b/src/main/java/com/fairticket/domain/reservation/service/SeatAssignmentConsumer.java
@@ -1,0 +1,33 @@
+package com.fairticket.domain.reservation.service;
+
+import com.fairticket.global.config.KafkaTopics;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * seat-assignment 토픽 Consumer 뼈대
+ * 실제 좌석 배정 로직 연결은 추후 이슈에서 진행
+ */
+@Slf4j
+@Component
+public class SeatAssignmentConsumer {
+
+    @KafkaListener(
+            topics = KafkaTopics.SEAT_ASSIGNMENT,
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void handleSeatAssignment(
+            @Payload String message,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.OFFSET) long offset) {
+        log.info("[Kafka] seat-assignment 수신: topic={}, offset={}, message={}",
+                topic, offset, message);
+
+        // TODO: 실제 좌석 배정 로직 연결 (추후 이슈)
+        // lotteryTrackService.assignSeat(event) or liveTrackService.confirmSeat(event)
+    }
+}

--- a/src/main/java/com/fairticket/global/config/KafkaConfig.java
+++ b/src/main/java/com/fairticket/global/config/KafkaConfig.java
@@ -1,0 +1,59 @@
+package com.fairticket.global.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    // Producer
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // Consumer
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(config);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/fairticket/global/config/KafkaTopics.java
+++ b/src/main/java/com/fairticket/global/config/KafkaTopics.java
@@ -1,0 +1,10 @@
+package com.fairticket.global.config;
+
+public class KafkaTopics {
+
+    private KafkaTopics() {}
+
+    public static final String SEAT_ASSIGNMENT     = "seat-assignment";
+    public static final String SEAT_ASSIGNMENT_DLQ = "seat-assignment-dlq";
+    public static final String REFUND              = "refund";
+}


### PR DESCRIPTION
## Summary
결제-배정 비동기 처리를 위한 Kafka 애플리케이션 레벨 기본 연동
docker-compose에 이미 구성된 Kafka 인프라 기반으로 Producer/Consumer 뼈대 구현

## Changes
- `KafkaConfig`: Producer/Consumer 공통 빈 설정
- `KafkaTopics`: 토픽 이름 상수 관리 (`seat-assignment`, `seat-assignment-dlq`, `refund`)
- `PaymentEventProducer`: 결제 완료/환불 이벤트 발행 Producer 구현
- `SeatAssignmentConsumer`: `seat-assignment` 토픽 수신 뼈대
- `RefundConsumer`: `refund` 토픽 수신 뼈대

## 테스트 결과
서버 기동 시 Kafka 브로커 정상 연결 확인
<img width="1579" height="561" alt="스크린샷 2026-02-13 오후 2 17 23" src="https://github.com/user-attachments/assets/1c193638-4dfb-40e4-953f-b1707ee3c4ee" />
- `seat-assignment`, `refund` 토픽 자동 생성 확인
- 파티션 리더 선출 정상 동작 확인

## 범위 외 (추후 이슈)

- `PaymentService`에 `eventProducer` 호출 연결 (Kafka 연동 검증 완료 후 진행 - Kafka 장애 시 결제 실패 방지)
- 실제 좌석 배정/환불 로직 연결
- DLQ 처리, 멱등성, 재시도 로직

## Closes
#34