### PR TITLE
feat: 좌석 풀 반환 구현 및 Redis 재고 동기화

### DIFF
--- a/src/main/java/com/fairticket/domain/seat/service/SeatPoolService.java
+++ b/src/main/java/com/fairticket/domain/seat/service/SeatPoolService.java
@@ -17,7 +17,9 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -31,22 +33,41 @@ public class SeatPoolService {
     /**
      * seats 테이블 기준으로 해당 회차 좌석 풀 초기화.
      * 단일 출처는 seats 테이블만 사용한다.
+     *
+     * 추가: 등급별 재고 카운터(stock:{scheduleId}:{grade})도 함께 초기화한다.
+     * 카운터 초기값 = 해당 등급 전체 좌석 수 (SeatPool Set의 크기와 동기화).
      */
     public Mono<Void> initializeSeatPools(Long scheduleId) {
         return seatRepository.findByScheduleId(scheduleId)
                 .collectMultimap(Seat::getZone, Seat::getSeatNumber)
                 .flatMap(zoneToNumbers -> Flux.fromIterable(zoneToNumbers.entrySet())
                         .flatMap(entry -> initializeSeatPoolWithNumbers(
-                                scheduleId, 
-                                entry.getKey(), 
-                                new ArrayList<>(entry.getValue())
-                        ))
+                                scheduleId,
+                                entry.getKey(),
+                                new ArrayList<>(entry.getValue())))
                         .then())
-                .doOnSuccess(v -> log.info("좌석 풀 초기화 완료: scheduleId={}", scheduleId));
+                .then(initializeStockCounters(scheduleId))
+                .doOnSuccess(v -> log.info("좌석 풀 + 재고 카운터 초기화 완료: scheduleId={}", scheduleId));
     }
 
     /**
-     * 지정한 구역·좌석 번호 목록으로 Redis 풀 초기화
+     * 등급별 재고 카운터 초기화.
+     * seats 테이블에서 scheduleId 기준 등급별 좌석 수를 집계하여 stock 키에 저장.
+     */
+    private Mono<Void> initializeStockCounters(Long scheduleId) {
+        return seatRepository.findSeatCountByScheduleIdGroupByGrade(scheduleId)
+                .flatMap(gradeSeatCount -> {
+                    String stockKey = RedisKeyGenerator.stockKey(scheduleId, gradeSeatCount.getGrade());
+                    String countValue = String.valueOf(gradeSeatCount.getCount());
+                    return redisTemplate.opsForValue().set(stockKey, countValue)
+                            .doOnSuccess(v -> log.info("재고 카운터 초기화: scheduleId={}, grade={}, stock={}",
+                                    scheduleId, gradeSeatCount.getGrade(), countValue));
+                })
+                .then();
+    }
+
+    /**
+     * 지정한 구역·좌석 번호 목록으로 Redis 풀 초기화.
      * 기존 데이터를 삭제하고 새로 초기화합니다.
      */
     public Mono<Void> initializeSeatPoolWithNumbers(Long scheduleId, String zone, List<String> seatNumbers) {
@@ -54,11 +75,10 @@ public class SeatPoolService {
             return Mono.empty();
         }
         String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
-        // 기존 키 삭제 후 새로 추가
         return redisTemplate.delete(poolKey)
                 .then(redisTemplate.opsForSet()
                         .add(poolKey, seatNumbers.toArray(new String[0])))
-                .doOnSuccess(c -> log.info("좌석 풀 초기화: scheduleId={}, zone={}, count={}", 
+                .doOnSuccess(c -> log.info("좌석 풀 초기화: scheduleId={}, zone={}, count={}",
                         scheduleId, zone, seatNumbers.size()))
                 .then();
     }
@@ -102,7 +122,7 @@ public class SeatPoolService {
     }
 
     /**
-     * 특정 좌석 선택 (풀에서 제거). 
+     * 특정 좌석 선택 (풀에서 제거).
      * @return true: 성공, false: 이미 없음
      */
     public Mono<Boolean> selectSeat(Long scheduleId, String zone, String seatNumber) {
@@ -127,7 +147,7 @@ public class SeatPoolService {
     }
 
     /**
-     * 랜덤 좌석 추출 (추첨: 해당 등급에 속한 구역들 중 하나에서 pop). 
+     * 랜덤 좌석 추출 (추첨: 해당 등급에 속한 구역들 중 하나에서 pop).
      * 라이브 종료 후 추첨 배정 시 사용
      */
     public Mono<ZoneSeatAssignmentResponse> popRandomSeat(Long scheduleId, String grade) {
@@ -140,10 +160,10 @@ public class SeatPoolService {
                     int idx = ThreadLocalRandom.current().nextInt(zones.size());
                     String zone = zones.get(idx).getZone();
                     String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
-                    
+
                     return redisTemplate.opsForSet().pop(poolKey)
                             .map(seatNumber -> {
-                                log.info("좌석 추출: scheduleId={}, grade={}, zone={}, seat={}", 
+                                log.info("좌석 추출: scheduleId={}, grade={}, zone={}, seat={}",
                                         scheduleId, grade, zone, seatNumber);
                                 return new ZoneSeatAssignmentResponse(zone, seatNumber);
                             });
@@ -162,7 +182,7 @@ public class SeatPoolService {
     }
 
     /**
-     * 추첨 쿼터: 등급별 추첨에 쓸 수 있는 최대 좌석 수. 
+     * 추첨 쿼터: 등급별 추첨에 쓸 수 있는 최대 좌석 수.
      * seats 테이블 기준 해당 등급 좌석 수의 절반.
      */
     public Mono<Long> getRemainingSeatsLottery(Long scheduleId, String grade) {

--- a/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
@@ -68,4 +68,24 @@ public class RedisKeyGenerator {
     public static String lotteryAssignedKey(Long scheduleId) {
         return String.format("lottery-assigned:%d", scheduleId);
     }
+
+    // 활성 스케줄 목록 (KEYS 명령어 대체) - active-schedules
+    public static String activeSchedulesKey() {
+        return "active-schedules";
+    }
+
+    // JWT 블랙리스트 키 (로그아웃 시 토큰 무효화) - blacklist:{token}
+    public static String blacklistKey(String token) {
+        return "blacklist:" + token;
+    }
+
+    /**
+     * 등급별 잔여 재고 카운터 키 (String, atomic INCR/DECR 전용)
+     * - 결제 완료 시 DECR, 타임아웃/취소 시 INCR
+     * - SeatPool(Set)의 빠른 재고 확인용 캐시. 단일 출처는 seats 테이블.
+     * stock:{scheduleId}:{grade}
+     */
+    public static String stockKey(Long scheduleId, String grade) {
+        return String.format("stock:%d:%s", scheduleId, grade);
+    }
 }

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -155,7 +155,7 @@ ON CONFLICT DO NOTHING;
 
 -- 공연 회차
 INSERT INTO schedules (concert_id, date_time, total_seats, ticket_open_at, ticket_close_at, status) VALUES
-    (1, '2026-03-15 19:00:00', 1000, '2026-02-09 20:00:00', '2026-03-15 18:00:00', 'OPEN'),
+    (1, NOW() + INTERVAL '30 days', 1000, NOW(), NOW() + INTERVAL '5 hours', 'OPEN'),
     (2, '2026-04-20 18:00:00', 1500, '2026-02-20 20:00:00', '2026-04-20 17:00:00', 'UPCOMING'),
     (1, '2026-01-10 19:00:00', 800, '2025-12-01 20:00:00', '2026-01-10 18:00:00', 'CLOSED')
 ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## 개요
결제 흐름에서 누락되어 있던 Redis 재고 카운터(`stock:{scheduleId}:{grade}`) 연동을 완성하고,
`RedisKeyExpiredListener.restoreSeat()`의 빈 껍데기 구현을 완료합니다.

---

## 변경 파일
| 파일 | 변경 유형 | 설명 |
|---|---|---|
| `RedisKeyGenerator` | 추가 | `stockKey(scheduleId, grade)` 메서드 추가 |
| `SeatPoolService` | 수정 | `initializeSeatPools()` 시 등급별 재고 카운터 초기화 추가 |
| `PaymentService` | 수정 | 결제 준비 시 재고 검증, 결제 완료 시 재고 DECR |
| `RedisKeyExpiredListener` | 수정 | `restoreSeat()` 실제 구현, 타임아웃 시 재고 INCR 복구 |

---

## 상세 내용

### 재고 카운터 설계
- `stock:{scheduleId}:{grade}` 키를 String 타입으로 관리하며 INCR/DECR만 사용합니다.  
- 단일 출처는 `seats` 테이블이고, 이 카운터는 결제 준비 단계의 빠른 재고 확인용 캐시입니다.

| 시점 | 연산 |
|---|---|
| 좌석 풀 초기화 (`initializeSeatPools`) | SET (등급별 전체 좌석 수) |
| 결제 완료 (`completePayment`) | DECR × quantity |
| 결제 타임아웃 (`handlePaymentTimeout`) | INCR × quantity |

### `restoreSeat()` 구현
기존 빈 껍데기를 `ReservationSeat` 기반으로 실제 구현했습니다.
- **라이브 트랙**: `ReservationSeat`에서 좌석 목록 조회 → `SeatPoolService.returnSeat()` 호출
- **추첨 트랙**: `PENDING` 상태에서 타임아웃 = 좌석 미배정이므로 반환 불필요, 스킵

### `handlePaymentTimeout()` 스킵 조건 수정
- 존재하지 않는 `COMPLETED` 상태 참조를 제거하고, 실제 `ReservationStatus` enum 기준으로 변경했습니다.  
- `PENDING`이 아닌 모든 상태(결제완료/배정완료/취소/환불)는 이미 처리된 예약이므로 일괄 스킵합니다.

---

## 관련 이슈
- Closes #34