### PR TITLE
feat: 예약 조회 API, 결제 Redis 재고 연동, Kafka 이벤트 기반 처리

### DIFF
--- a/src/main/java/com/fairticket/domain/payment/dto/package-info.java
+++ b/src/main/java/com/fairticket/domain/payment/dto/package-info.java
@@ -1,0 +1,1 @@
+package com.fairticket.domain.payment.dto;

--- a/src/main/java/com/fairticket/domain/payment/dto/package-info.java
+++ b/src/main/java/com/fairticket/domain/payment/dto/package-info.java
@@ -1,1 +1,0 @@
-package com.fairticket.domain.payment.dto;

--- a/src/main/java/com/fairticket/domain/payment/service/PaymentEventProducer.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PaymentEventProducer.java
@@ -1,0 +1,56 @@
+package com.fairticket.domain.payment.service;
+
+import com.fairticket.global.config.KafkaTopics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentEventProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    // 결제 완료 이벤트 발행 → seat-assignment 토픽
+    // key: reservationId (같은 예약의 이벤트 순서 보장)
+    public Mono<Void> sendSeatAssignmentEvent(Long reservationId, Long userId, Long scheduleId, String grade) {
+        String message = String.format(
+                "{\"reservationId\":%d,\"userId\":%d,\"scheduleId\":%d,\"grade\":\"%s\"}",
+                reservationId, userId, scheduleId, grade
+        );
+
+        return Mono.fromCallable(() -> kafkaTemplate.send(
+                        KafkaTopics.SEAT_ASSIGNMENT,
+                        String.valueOf(reservationId),
+                        message))
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(result -> log.info("[Kafka] seat-assignment 발행: reservationId={}, grade={}",
+                        reservationId, grade))
+                .doOnError(e -> log.error("[Kafka] seat-assignment 발행 실패: reservationId={}, error={}",
+                        reservationId, e.getMessage()))
+                .then();
+    }
+
+    // 환불 이벤트 발행 → refund 토픽
+    public Mono<Void> sendRefundEvent(Long paymentId, Long reservationId, int amount, String reason) {
+        String message = String.format(
+                "{\"paymentId\":%d,\"reservationId\":%d,\"amount\":%d,\"reason\":\"%s\"}",
+                paymentId, reservationId, amount, reason
+        );
+
+        return Mono.fromCallable(() -> kafkaTemplate.send(
+                        KafkaTopics.REFUND,
+                        String.valueOf(paymentId),
+                        message))
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(result -> log.info("[Kafka] refund 발행: paymentId={}, amount={}",
+                        paymentId, amount))
+                .doOnError(e -> log.error("[Kafka] refund 발행 실패: paymentId={}, error={}",
+                        paymentId, e.getMessage()))
+                .then();
+    }
+}

--- a/src/main/java/com/fairticket/domain/payment/service/RefundConsumer.java
+++ b/src/main/java/com/fairticket/domain/payment/service/RefundConsumer.java
@@ -1,0 +1,32 @@
+package com.fairticket.domain.payment.service;
+
+import com.fairticket.global.config.KafkaTopics;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * refund 토픽 Consumer 뼈대
+ * 실제 환불 처리 로직 연결은 추후 이슈에서 진행
+ */
+@Slf4j
+@Component
+public class RefundConsumer {
+
+    @KafkaListener(
+            topics = KafkaTopics.REFUND,
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void handleRefund(
+            @Payload String message,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.OFFSET) long offset) {
+        log.info("[Kafka] refund 수신: topic={}, offset={}, message={}",
+                topic, offset, message);
+
+        // TODO: 실제 환불 처리 로직 연결 (추후 이슈)
+    }
+}

--- a/src/main/java/com/fairticket/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/fairticket/domain/reservation/controller/ReservationController.java
@@ -1,13 +1,23 @@
 package com.fairticket.domain.reservation.controller;
 
 import com.fairticket.domain.reservation.dto.CancellationWindowResponse;
+import com.fairticket.domain.reservation.dto.ReservationResponse;
 import com.fairticket.domain.reservation.service.CancellationWindowService;
 import com.fairticket.domain.reservation.service.ReservationCancelService;
+import com.fairticket.domain.reservation.service.ReservationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
+@Tag(name = "Reservation", description = "예약 조회/취소 API")
 @RestController
 @RequestMapping("/api/v1/reservations")
 @RequiredArgsConstructor
@@ -15,19 +25,54 @@ public class ReservationController {
 
     private final ReservationCancelService reservationCancelService;
     private final CancellationWindowService cancellationWindowService;
+    private final ReservationService reservationService;
+
+    @Operation(
+            summary = "결제 대기 중인 예약 조회",
+            description = "사용자가 예약 생성 후 페이지 이동/새로고침 등으로 예약ID를 유실한 경우, " +
+                    "해당 공연 일정에서 결제 대기 중(PENDING)인 예약을 재조회하여 reservationId를 획득할 수 있습니다. " +
+                    "결제 준비 API(POST /api/v1/payment/prepare)의 입력값으로 사용됩니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "결제 대기 중인 예약 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ReservationResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 공연 일정에 결제 대기 중인 예약이 없음"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @GetMapping("/pending")
+    public Mono<ResponseEntity<ReservationResponse>> getPendingReservation(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader("X-User-Id") Long userId,
+            @Parameter(description = "공연 일정 ID", required = true)
+            @RequestParam Long scheduleId) {
+        return reservationService.getPendingReservation(userId, scheduleId)
+                .map(ResponseEntity::ok);
+    }
 
     // 예약 취소 (추첨/라이브 공통). 티켓 오픈 2시간 후 ~ 24시간 이내만 가능.
+    @Operation(
+            summary = "예약 취소",
+            description = "배정된 또는 배정 대기 중인 예약을 취소합니다. 티켓 오픈 2시간 후부터 24시간 이내만 가능합니다."
+    )
     @DeleteMapping("/{reservationId}")
     public Mono<ResponseEntity<Void>> cancelReservation(
+            @Parameter(description = "예약 ID", required = true)
             @PathVariable Long reservationId,
+            @Parameter(description = "사용자 ID", required = true)
             @RequestHeader("X-User-Id") Long userId) {
         return reservationCancelService.cancelReservation(reservationId, userId)
                 .then(Mono.just(ResponseEntity.noContent().<Void>build()));
     }
 
     // 해당 회차 취소 가능 기간 조회
+    @Operation(
+            summary = "예약 취소 가능 기간 조회",
+            description = "해당 공연 일정의 티켓 오픈 시간과 취소 가능 윈도우를 조회합니다."
+    )
     @GetMapping("/schedules/{scheduleId}/cancellation-window")
-    public Mono<ResponseEntity<CancellationWindowResponse>> getCancellationWindow(@PathVariable Long scheduleId) {
+    public Mono<ResponseEntity<CancellationWindowResponse>> getCancellationWindow(
+            @Parameter(description = "공연 일정 ID", required = true)
+            @PathVariable Long scheduleId) {
         return cancellationWindowService.getCancellationWindow(scheduleId)
                 .map(ResponseEntity::ok);
     }

--- a/src/main/java/com/fairticket/domain/reservation/dto/ReservationResponse.java
+++ b/src/main/java/com/fairticket/domain/reservation/dto/ReservationResponse.java
@@ -1,5 +1,6 @@
 package com.fairticket.domain.reservation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,14 +8,33 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Schema(description = "예약 정보 응답")
 public class ReservationResponse {
+    @Schema(description = "예약 ID", example = "1")
     private Long id;
+
+    @Schema(description = "공연 일정 ID", example = "1")
     private Long scheduleId;
+
+    @Schema(description = "좌석 등급 (VIP, R, S, A)", example = "VIP")
     private String grade;
+
+    @Schema(description = "예약 좌석 수량", example = "2")
     private Integer quantity;
+
+    @Schema(description = "배정받은 좌석 번호들 (쉼표 구분)")
     private String seatNumbers;
+
+    @Schema(description = "트랙 타입 (LOTTERY/LIVE)", example = "LIVE")
     private String trackType;
+
+    @Schema(description = "예약 상태 (PENDING/PAID/PAID_PENDING_SEAT/ASSIGNED/CANCELLED/REFUNDED)", example = "PENDING")
     private String status;
+
+    @Schema(description = "메시지 (선택 사항)")
     private String message;
+
+    @Schema(description = "결제 만료 시간 (예약 생성 후 5분)", example = "2026-02-16T15:30:00")
     private LocalDateTime paymentDeadline;
 }
+

--- a/src/main/java/com/fairticket/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/fairticket/domain/reservation/repository/ReservationRepository.java
@@ -52,4 +52,7 @@ public interface ReservationRepository extends ReactiveCrudRepository<Reservatio
            "WHERE schedule_id = :scheduleId AND track_type = 'LOTTERY' " +
            "AND status IN ('PENDING', 'PAID_PENDING_SEAT') GROUP BY grade")
     Flux<GradeReservedSum> findLotteryReservedSumByScheduleIdGroupByGrade(Long scheduleId);
+
+    // 사용자의 해당 공연 일정의 PENDING 상태 예약 조회 (결제 대기 중인 예약 재조회용)
+    Mono<Reservation> findFirstByUserIdAndScheduleIdAndStatusOrderByCreatedAtDesc(Long userId, Long scheduleId, String status);
 }

--- a/src/main/java/com/fairticket/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/fairticket/domain/reservation/service/ReservationService.java
@@ -1,0 +1,61 @@
+package com.fairticket.domain.reservation.service;
+
+import com.fairticket.domain.reservation.dto.ReservationResponse;
+import com.fairticket.domain.reservation.entity.Reservation;
+import com.fairticket.domain.reservation.entity.ReservationStatus;
+import com.fairticket.domain.reservation.repository.ReservationRepository;
+import com.fairticket.global.exception.BusinessException;
+import com.fairticket.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    /**
+     * 사용자의 해당 공연 일정에서 결제 대기 중인(PENDING) 예약을 조회합니다.
+     * 결제 준비 API의 입력으로 사용할 reservationId를 재획득하는 용도입니다.
+     *
+     * @param userId 사용자 ID
+     * @param scheduleId 공연 일정 ID
+     * @return 결제 대기 중인 예약 정보
+     * @throws BusinessException 해당 예약이 없으면 예외 발생
+     */
+    public Mono<ReservationResponse> getPendingReservation(Long userId, Long scheduleId) {
+        return reservationRepository.findFirstByUserIdAndScheduleIdAndStatusOrderByCreatedAtDesc(
+                userId, scheduleId, ReservationStatus.PENDING.name())
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.RESERVATION_NOT_FOUND)))
+                .map(this::toReservationResponse)
+                .doOnSuccess(response -> log.info("결제 대기 중 예약 조회: userId={}, scheduleId={}, reservationId={}", 
+                        userId, scheduleId, response.getId()))
+                .doOnError(error -> log.warn("예약 조회 실패: userId={}, scheduleId={}, error={}", 
+                        userId, scheduleId, error.getMessage()));
+    }
+
+    /**
+     * Reservation 엔티티를 ReservationResponse DTO로 변환합니다.
+     */
+    private ReservationResponse toReservationResponse(Reservation reservation) {
+        // 결제 만료 시간: 예약 생성 후 5분 (Payment 타이머 기준)
+        LocalDateTime paymentDeadline = reservation.getCreatedAt() != null ? 
+                reservation.getCreatedAt().plusMinutes(5) : null;
+
+        return ReservationResponse.builder()
+                .id(reservation.getId())
+                .scheduleId(reservation.getScheduleId())
+                .grade(reservation.getGrade())
+                .quantity(reservation.getQuantity())
+                .trackType(reservation.getTrackType())
+                .status(reservation.getStatus())
+                .paymentDeadline(paymentDeadline)
+                .build();
+    }
+}

--- a/src/main/java/com/fairticket/domain/reservation/service/SeatAssignmentConsumer.java
+++ b/src/main/java/com/fairticket/domain/reservation/service/SeatAssignmentConsumer.java
@@ -1,0 +1,33 @@
+package com.fairticket.domain.reservation.service;
+
+import com.fairticket.global.config.KafkaTopics;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * seat-assignment 토픽 Consumer 뼈대
+ * 실제 좌석 배정 로직 연결은 추후 이슈에서 진행
+ */
+@Slf4j
+@Component
+public class SeatAssignmentConsumer {
+
+    @KafkaListener(
+            topics = KafkaTopics.SEAT_ASSIGNMENT,
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void handleSeatAssignment(
+            @Payload String message,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.OFFSET) long offset) {
+        log.info("[Kafka] seat-assignment 수신: topic={}, offset={}, message={}",
+                topic, offset, message);
+
+        // TODO: 실제 좌석 배정 로직 연결 (추후 이슈)
+        // lotteryTrackService.assignSeat(event) or liveTrackService.confirmSeat(event)
+    }
+}

--- a/src/main/java/com/fairticket/domain/seat/service/SeatPoolService.java
+++ b/src/main/java/com/fairticket/domain/seat/service/SeatPoolService.java
@@ -17,7 +17,9 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -31,22 +33,41 @@ public class SeatPoolService {
     /**
      * seats 테이블 기준으로 해당 회차 좌석 풀 초기화.
      * 단일 출처는 seats 테이블만 사용한다.
+     *
+     * 추가: 등급별 재고 카운터(stock:{scheduleId}:{grade})도 함께 초기화한다.
+     * 카운터 초기값 = 해당 등급 전체 좌석 수 (SeatPool Set의 크기와 동기화).
      */
     public Mono<Void> initializeSeatPools(Long scheduleId) {
         return seatRepository.findByScheduleId(scheduleId)
                 .collectMultimap(Seat::getZone, Seat::getSeatNumber)
                 .flatMap(zoneToNumbers -> Flux.fromIterable(zoneToNumbers.entrySet())
                         .flatMap(entry -> initializeSeatPoolWithNumbers(
-                                scheduleId, 
-                                entry.getKey(), 
-                                new ArrayList<>(entry.getValue())
-                        ))
+                                scheduleId,
+                                entry.getKey(),
+                                new ArrayList<>(entry.getValue())))
                         .then())
-                .doOnSuccess(v -> log.info("좌석 풀 초기화 완료: scheduleId={}", scheduleId));
+                .then(initializeStockCounters(scheduleId))
+                .doOnSuccess(v -> log.info("좌석 풀 + 재고 카운터 초기화 완료: scheduleId={}", scheduleId));
     }
 
     /**
-     * 지정한 구역·좌석 번호 목록으로 Redis 풀 초기화
+     * 등급별 재고 카운터 초기화.
+     * seats 테이블에서 scheduleId 기준 등급별 좌석 수를 집계하여 stock 키에 저장.
+     */
+    private Mono<Void> initializeStockCounters(Long scheduleId) {
+        return seatRepository.findSeatCountByScheduleIdGroupByGrade(scheduleId)
+                .flatMap(gradeSeatCount -> {
+                    String stockKey = RedisKeyGenerator.stockKey(scheduleId, gradeSeatCount.getGrade());
+                    String countValue = String.valueOf(gradeSeatCount.getCount());
+                    return redisTemplate.opsForValue().set(stockKey, countValue)
+                            .doOnSuccess(v -> log.info("재고 카운터 초기화: scheduleId={}, grade={}, stock={}",
+                                    scheduleId, gradeSeatCount.getGrade(), countValue));
+                })
+                .then();
+    }
+
+    /**
+     * 지정한 구역·좌석 번호 목록으로 Redis 풀 초기화.
      * 기존 데이터를 삭제하고 새로 초기화합니다.
      */
     public Mono<Void> initializeSeatPoolWithNumbers(Long scheduleId, String zone, List<String> seatNumbers) {
@@ -54,11 +75,10 @@ public class SeatPoolService {
             return Mono.empty();
         }
         String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
-        // 기존 키 삭제 후 새로 추가
         return redisTemplate.delete(poolKey)
                 .then(redisTemplate.opsForSet()
                         .add(poolKey, seatNumbers.toArray(new String[0])))
-                .doOnSuccess(c -> log.info("좌석 풀 초기화: scheduleId={}, zone={}, count={}", 
+                .doOnSuccess(c -> log.info("좌석 풀 초기화: scheduleId={}, zone={}, count={}",
                         scheduleId, zone, seatNumbers.size()))
                 .then();
     }
@@ -102,7 +122,7 @@ public class SeatPoolService {
     }
 
     /**
-     * 특정 좌석 선택 (풀에서 제거). 
+     * 특정 좌석 선택 (풀에서 제거).
      * @return true: 성공, false: 이미 없음
      */
     public Mono<Boolean> selectSeat(Long scheduleId, String zone, String seatNumber) {
@@ -127,7 +147,7 @@ public class SeatPoolService {
     }
 
     /**
-     * 랜덤 좌석 추출 (추첨: 해당 등급에 속한 구역들 중 하나에서 pop). 
+     * 랜덤 좌석 추출 (추첨: 해당 등급에 속한 구역들 중 하나에서 pop).
      * 라이브 종료 후 추첨 배정 시 사용
      */
     public Mono<ZoneSeatAssignmentResponse> popRandomSeat(Long scheduleId, String grade) {
@@ -140,10 +160,10 @@ public class SeatPoolService {
                     int idx = ThreadLocalRandom.current().nextInt(zones.size());
                     String zone = zones.get(idx).getZone();
                     String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
-                    
+
                     return redisTemplate.opsForSet().pop(poolKey)
                             .map(seatNumber -> {
-                                log.info("좌석 추출: scheduleId={}, grade={}, zone={}, seat={}", 
+                                log.info("좌석 추출: scheduleId={}, grade={}, zone={}, seat={}",
                                         scheduleId, grade, zone, seatNumber);
                                 return new ZoneSeatAssignmentResponse(zone, seatNumber);
                             });
@@ -162,7 +182,7 @@ public class SeatPoolService {
     }
 
     /**
-     * 추첨 쿼터: 등급별 추첨에 쓸 수 있는 최대 좌석 수. 
+     * 추첨 쿼터: 등급별 추첨에 쓸 수 있는 최대 좌석 수.
      * seats 테이블 기준 해당 등급 좌석 수의 절반.
      */
     public Mono<Long> getRemainingSeatsLottery(Long scheduleId, String grade) {

--- a/src/main/java/com/fairticket/global/config/KafkaConfig.java
+++ b/src/main/java/com/fairticket/global/config/KafkaConfig.java
@@ -1,0 +1,59 @@
+package com.fairticket.global.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    // Producer
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // Consumer
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(config);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/fairticket/global/config/KafkaTopics.java
+++ b/src/main/java/com/fairticket/global/config/KafkaTopics.java
@@ -1,0 +1,10 @@
+package com.fairticket.global.config;
+
+public class KafkaTopics {
+
+    private KafkaTopics() {}
+
+    public static final String SEAT_ASSIGNMENT     = "seat-assignment";
+    public static final String SEAT_ASSIGNMENT_DLQ = "seat-assignment-dlq";
+    public static final String REFUND              = "refund";
+}

--- a/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
@@ -68,4 +68,24 @@ public class RedisKeyGenerator {
     public static String lotteryAssignedKey(Long scheduleId) {
         return String.format("lottery-assigned:%d", scheduleId);
     }
+
+    // 활성 스케줄 목록 (KEYS 명령어 대체) - active-schedules
+    public static String activeSchedulesKey() {
+        return "active-schedules";
+    }
+
+    // JWT 블랙리스트 키 (로그아웃 시 토큰 무효화) - blacklist:{token}
+    public static String blacklistKey(String token) {
+        return "blacklist:" + token;
+    }
+
+    /**
+     * 등급별 잔여 재고 카운터 키 (String, atomic INCR/DECR 전용)
+     * - 결제 완료 시 DECR, 타임아웃/취소 시 INCR
+     * - SeatPool(Set)의 빠른 재고 확인용 캐시. 단일 출처는 seats 테이블.
+     * stock:{scheduleId}:{grade}
+     */
+    public static String stockKey(Long scheduleId, String grade) {
+        return String.format("stock:%d:%s", scheduleId, grade);
+    }
 }

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -155,7 +155,7 @@ ON CONFLICT DO NOTHING;
 
 -- 공연 회차
 INSERT INTO schedules (concert_id, date_time, total_seats, ticket_open_at, ticket_close_at, status) VALUES
-    (1, '2026-03-15 19:00:00', 1000, '2026-02-09 20:00:00', '2026-03-15 18:00:00', 'OPEN'),
+    (1, NOW() + INTERVAL '30 days', 1000, NOW(), NOW() + INTERVAL '5 hours', 'OPEN'),
     (2, '2026-04-20 18:00:00', 1500, '2026-02-20 20:00:00', '2026-04-20 17:00:00', 'UPCOMING'),
     (1, '2026-01-10 19:00:00', 800, '2025-12-01 20:00:00', '2026-01-10 18:00:00', 'CLOSED')
 ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- 내 예약 조회(Reservation ID) API 구현 (#51)
- 결제 흐름 Redis 재고 카운터 연동 및 좌석 반환 구현
- Kafka Producer/Consumer 기본 연동 세팅 (결제 이벤트, 환불, 좌석 배정)
- package-info.java 파일 정리

## 주의
- `RedisKeyGenerator.java`, `init.sql` 2개 파일 충돌 예상 — 머지 시 수동 해결 필요
- develop에 이미 반영된 concert API, queue 고도화 등과 겹치는 부분 있음 — develop 기준 유지 권장

## Test plan
- [ ] 충돌 해결 후 빌드 확인
- [ ] 예약 조회 API 동작 확인
- [ ] Kafka 토픽 발행/소비 정상 동작 확인