### PR TITLE
 feat: 스케줄러 종료 조건 수정, 미구현 플로우 완성, 추첨 좌석 보호, 마이페이지 API

### DIFF
--- a/src/main/java/com/fairticket/domain/concert/entity/ScheduleStatus.java
+++ b/src/main/java/com/fairticket/domain/concert/entity/ScheduleStatus.java
@@ -3,5 +3,6 @@ package com.fairticket.domain.concert.entity;
 public enum ScheduleStatus {
     UPCOMING,
     OPEN,
-    CLOSED
+    CLOSED,
+    COMPLETED
 }

--- a/src/main/java/com/fairticket/domain/concert/repository/ScheduleRepository.java
+++ b/src/main/java/com/fairticket/domain/concert/repository/ScheduleRepository.java
@@ -10,6 +10,9 @@ public interface ScheduleRepository extends ReactiveCrudRepository<Schedule, Lon
 
     Flux<Schedule> findByConcertId(Long concertId);
 
-    // 티켓 오픈 시각이 주어진 시각 이전(이하)인 회차만 조회. 스케줄러에서 활성 회차만 처리할 때 사용 
+    // 티켓 오픈 시각이 주어진 시각 이전(이하)인 회차만 조회. 스케줄러에서 활성 회차만 처리할 때 사용
     Flux<Schedule> findByTicketOpenAtLessThanEqual(LocalDateTime time);
+
+    // 스케줄러용: 오픈 시각 이전이면서 COMPLETED가 아닌 활성 회차만 조회
+    Flux<Schedule> findByTicketOpenAtLessThanEqualAndStatusNot(LocalDateTime time, String status);
 }

--- a/src/main/java/com/fairticket/domain/concert/service/ConcertService.java
+++ b/src/main/java/com/fairticket/domain/concert/service/ConcertService.java
@@ -102,10 +102,12 @@ public class ConcertService {
         if (schedules.isEmpty()) return "sold-out";
         boolean anyOpen = schedules.stream().anyMatch(s -> ScheduleStatus.OPEN.name().equals(s.getStatus()));
         boolean allUpcoming = schedules.stream().allMatch(s -> ScheduleStatus.UPCOMING.name().equals(s.getStatus()));
-        boolean allClosed = schedules.stream().allMatch(s -> ScheduleStatus.CLOSED.name().equals(s.getStatus()));
+        boolean allClosedOrCompleted = schedules.stream().allMatch(s ->
+                ScheduleStatus.CLOSED.name().equals(s.getStatus())
+                        || ScheduleStatus.COMPLETED.name().equals(s.getStatus()));
         if (anyOpen) return "on-sale";
         if (allUpcoming) return "coming-soon";
-        if (allClosed) return "sold-out";
+        if (allClosedOrCompleted) return "sold-out";
         return "on-sale"; // mixed
     }
 
@@ -139,7 +141,7 @@ public class ConcertService {
                 .findAvailableSeatCountByScheduleIdGroupByGrade(refSchedule.getId())
                 .collectList()
                 .map(list -> list.stream()
-                        .collect(Collectors.toMap(GradeSeatCount::getGrade, GradeSeatCount::getCount)));
+                        .collect(Collectors.toMap(GradeSeatCount::getGrade, g -> g.getCount() != null ? g.getCount() : 0L)));
 
         return Mono.zip(gradesMono, totalByGrade, availableByGrade)
                 .map(tuple -> {

--- a/src/main/java/com/fairticket/domain/payment/dto/WebhookRequest.java
+++ b/src/main/java/com/fairticket/domain/payment/dto/WebhookRequest.java
@@ -1,11 +1,15 @@
 package com.fairticket.domain.payment.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class WebhookRequest {
+    @JsonProperty("imp_uid")
     private String impUid;       // PortOne 결제 고유번호
+
+    @JsonProperty("merchant_uid")
     private String merchantUid;  // 우리 시스템 주문번호
 }

--- a/src/main/java/com/fairticket/domain/payment/service/PaymentExpiryScheduler.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PaymentExpiryScheduler.java
@@ -1,0 +1,85 @@
+package com.fairticket.domain.payment.service;
+
+import com.fairticket.domain.payment.entity.PaymentStatus;
+import com.fairticket.domain.payment.repository.PaymentRepository;
+import com.fairticket.domain.reservation.constants.ReservationConstants;
+import com.fairticket.domain.reservation.entity.ReservationStatus;
+import com.fairticket.domain.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+// 결제 준비(prepare) 후 결제창 미진입(impUid=null)으로 5분 경과한 Payment를 CANCELLED 처리.
+// PaymentVerificationScheduler는 impUid가 있는 결제만 PortOne 검증하므로,
+// impUid=null인 결제는 이 스케줄러가 정리한다. 추첨/라이브 공통.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentExpiryScheduler {
+
+    private final PaymentRepository paymentRepository;
+    private final ReservationRepository reservationRepository;
+    private final RedissonClient redissonClient;
+
+    @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
+    public void cancelExpiredUnpaidPayments() {
+        RLock lock = redissonClient.getLock("scheduler:payment-expiry");
+        boolean acquired = false;
+        try {
+            acquired = lock.tryLock(0, 55, TimeUnit.SECONDS);
+            if (!acquired) return;
+
+            LocalDateTime threshold = LocalDateTime.now()
+                    .minusMinutes(ReservationConstants.PAYMENT_DEADLINE_MINUTES);
+
+            paymentRepository.findByStatus(PaymentStatus.PENDING.name())
+                    .filter(payment -> payment.getCreatedAt() != null
+                            && payment.getCreatedAt().isBefore(threshold))
+                    .filter(payment -> payment.getImpUid() == null)
+                    .flatMap(payment -> {
+                        payment.setStatus(PaymentStatus.CANCELLED.name());
+                        payment.setUpdatedAt(LocalDateTime.now());
+                        return paymentRepository.save(payment)
+                                .flatMap(saved -> cancelReservationIfPending(saved.getReservationId()))
+                                .doOnSuccess(v -> log.info("미결제 자동 취소: paymentId={}, reservationId={}",
+                                        payment.getId(), payment.getReservationId()))
+                                .thenReturn(payment);
+                    })
+                    .count()
+                    .doOnSuccess(count -> {
+                        if (count > 0) {
+                            log.info("미결제 만료 처리: {}건", count);
+                        }
+                    })
+                    .block(Duration.ofSeconds(30));
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.error("미결제 만료 스케줄러 오류", e);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+    private Mono<Void> cancelReservationIfPending(Long reservationId) {
+        return reservationRepository.findById(reservationId)
+                .filter(r -> ReservationStatus.PENDING.name().equals(r.getStatus()))
+                .flatMap(reservation -> {
+                    reservation.setStatus(ReservationStatus.CANCELLED.name());
+                    reservation.setUpdatedAt(LocalDateTime.now());
+                    return reservationRepository.save(reservation);
+                })
+                .then();
+    }
+}

--- a/src/main/java/com/fairticket/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PaymentService.java
@@ -10,6 +10,7 @@ import com.fairticket.domain.reservation.constants.ReservationConstants;
 import com.fairticket.domain.reservation.entity.Reservation;
 import com.fairticket.domain.reservation.entity.TrackType;
 import com.fairticket.domain.reservation.repository.ReservationRepository;
+import com.fairticket.domain.reservation.service.LiveTrackService;
 import com.fairticket.domain.reservation.service.LotteryTrackService;
 import com.fairticket.global.exception.BusinessException;
 import com.fairticket.global.exception.ErrorCode;
@@ -35,6 +36,7 @@ public class PaymentService {
     private final PortOneClient portOneClient;
     private final PaymentTimerService timerService;
     private final LotteryTrackService lotteryTrackService;
+    private final LiveTrackService liveTrackService;
     private final ReactiveRedisTemplate<String, String> redisTemplate;
 
     // 결제 준비 (결제창 호출 전).
@@ -132,8 +134,10 @@ public class PaymentService {
                                                 reservation.getScheduleId()))
                                         .thenReturn(payment);
                             }
-                            // Todo: 라이브 트랙: 홀드 해제
-                            return decrementStock.thenReturn(payment);
+                            return decrementStock
+                                    .then(liveTrackService.onPaymentCompleted(
+                                            payment.getReservationId()))
+                                    .thenReturn(payment);
                         }))
                 .doOnSuccess(payment -> log.info("결제 완료: paymentId={}, merchantUid={}",
                         payment.getId(), payment.getMerchantUid()));
@@ -186,7 +190,6 @@ public class PaymentService {
         return Flux.range(0, quantity)
                 .flatMap(i -> redisTemplate.opsForValue().decrement(stockKey))
                 .then()
-                // 카운터가 없으면(키 미존재) 차감 시도 시 음수가 되지 않도록 guard
                 .doOnSuccess(v -> log.info("재고 카운터 차감: scheduleId={}, grade={}, qty=-{}",
                         reservation.getScheduleId(), reservation.getGrade(), quantity));
     }

--- a/src/main/java/com/fairticket/domain/payment/service/PaymentVerificationScheduler.java
+++ b/src/main/java/com/fairticket/domain/payment/service/PaymentVerificationScheduler.java
@@ -6,10 +6,13 @@ import com.fairticket.domain.reservation.entity.ReservationStatus;
 import com.fairticket.domain.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
@@ -21,63 +24,72 @@ public class PaymentVerificationScheduler {
     private final PaymentRepository paymentRepository;
     private final ReservationRepository reservationRepository;
     private final PortOneClient portOneClient;
+    private final RedissonClient redissonClient;
 
     @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
     public void verifyPendingPayments() {
-        LocalDateTime threshold = LocalDateTime.now().minusMinutes(5);
+        RLock lock = redissonClient.getLock("scheduler:payment-verification");
+        boolean acquired = false;
+        try {
+            acquired = lock.tryLock(0, 55, TimeUnit.SECONDS);
+            if (!acquired) return;
 
-        paymentRepository.findByStatus(PaymentStatus.PENDING.name())
-                .filter(payment -> payment.getCreatedAt() != null
-                        && payment.getCreatedAt().isBefore(threshold))
-                .filter(payment -> payment.getImpUid() != null)
-                .flatMap(payment -> portOneClient.verifyPayment(payment.getImpUid())
-                        .flatMap(verification -> {
-                            switch (verification.getStatus()) {
-                                case COMPLETED -> {
-                                    // PG에서 결제 완료 → DB 동기화
-                                    log.info("결제 불일치 복구 - 완료 처리: paymentId={}, impUid={}",
-                                            payment.getId(), payment.getImpUid());
-                                    payment.setStatus(PaymentStatus.COMPLETED.name());
-                                    payment.setPaidAt(LocalDateTime.now());
-                                    return paymentRepository.save(payment)
-                                            .flatMap(saved -> updateReservationStatus(
-                                                    saved.getReservationId(), ReservationStatus.PAID.name()));
+            LocalDateTime threshold = LocalDateTime.now().minusMinutes(5);
+
+            paymentRepository.findByStatus(PaymentStatus.PENDING.name())
+                    .filter(payment -> payment.getCreatedAt() != null
+                            && payment.getCreatedAt().isBefore(threshold))
+                    .filter(payment -> payment.getImpUid() != null)
+                    .flatMap(payment -> portOneClient.verifyPayment(payment.getImpUid())
+                            .flatMap(verification -> {
+                                switch (verification.getStatus()) {
+                                    case COMPLETED -> {
+                                        log.info("결제 불일치 복구 - 완료 처리: paymentId={}, impUid={}",
+                                                payment.getId(), payment.getImpUid());
+                                        payment.setStatus(PaymentStatus.COMPLETED.name());
+                                        payment.setPaidAt(LocalDateTime.now());
+                                        return paymentRepository.save(payment)
+                                                .flatMap(saved -> updateReservationStatus(
+                                                        saved.getReservationId(), ReservationStatus.PAID.name()));
+                                    }
+                                    case FAILED -> {
+                                        log.warn("결제 불일치 복구 - 실패 처리: paymentId={}, impUid={}",
+                                                payment.getId(), payment.getImpUid());
+                                        payment.setStatus(PaymentStatus.FAILED.name());
+                                        payment.setUpdatedAt(LocalDateTime.now());
+                                        return paymentRepository.save(payment)
+                                                .flatMap(saved -> updateReservationStatus(
+                                                        saved.getReservationId(), ReservationStatus.CANCELLED.name()));
+                                    }
+                                    default -> {
+                                        log.debug("결제 검증 대기 중: paymentId={}, status={}",
+                                                payment.getId(), verification.getStatus());
+                                        return Mono.just(payment);
+                                    }
                                 }
-                                case FAILED -> {
-                                    // PG에서 결제 실패 → DB 동기화
-                                    log.warn("결제 불일치 복구 - 실패 처리: paymentId={}, impUid={}",
-                                            payment.getId(), payment.getImpUid());
-                                    payment.setStatus(PaymentStatus.FAILED.name());
-                                    payment.setUpdatedAt(LocalDateTime.now());
-                                    return paymentRepository.save(payment)
-                                            .flatMap(saved -> updateReservationStatus(
-                                                    saved.getReservationId(), ReservationStatus.CANCELLED.name()));
-                                }
-                                default -> {
-                                    // 아직 처리 중 → Redis TTL 만료로 처리 대기
-                                    log.debug("결제 검증 대기 중: paymentId={}, status={}",
-                                            payment.getId(), verification.getStatus());
-                                    return Mono.just(payment);
-                                }
-                            }
-                        })
-                        .onErrorResume(e -> {
-                            log.warn("결제 검증 API 호출 실패: paymentId={}, error={}",
-                                    payment.getId(), e.getMessage());
-                            return Mono.just(payment);
-                        }))
-                .doOnSubscribe(s -> log.debug("결제 불일치 복구 스캔 시작"))
-                .count()
-                .doOnSuccess(count -> {
-                    if (count > 0) {
-                        log.info("결제 불일치 복구 처리: {}건", count);
-                    }
-                })
-                .onErrorResume(e -> {
-                    log.warn("결제 불일치 복구 스케줄러 오류: {}", e.getMessage());
-                    return Mono.just(0L);
-                })
-                .subscribe();
+                            })
+                            .onErrorResume(e -> {
+                                log.warn("결제 검증 API 호출 실패: paymentId={}, error={}",
+                                        payment.getId(), e.getMessage());
+                                return Mono.just(payment);
+                            }))
+                    .count()
+                    .doOnSuccess(count -> {
+                        if (count > 0) {
+                            log.info("결제 불일치 복구 처리: {}건", count);
+                        }
+                    })
+                    .block(Duration.ofSeconds(30));
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.error("결제 불일치 복구 스케줄러 오류", e);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 
     private Mono<Void> updateReservationStatus(Long reservationId, String status) {

--- a/src/main/java/com/fairticket/domain/queue/controller/QueueController.java
+++ b/src/main/java/com/fairticket/domain/queue/controller/QueueController.java
@@ -4,7 +4,6 @@ import com.fairticket.domain.queue.dto.QueueEntryResponse;
 import com.fairticket.domain.queue.dto.QueueStatusResponse;
 import com.fairticket.domain.queue.service.QueueService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -38,14 +37,7 @@ public class QueueController {
             @PathVariable Long scheduleId,
             @AuthenticationPrincipal Long userId) {
         return queueService.getQueueStatus(scheduleId, userId)
-                .map(status -> {
-                    if ("READY".equals(status.getStatus())) {
-                        return ResponseEntity.status(HttpStatus.TEMPORARY_REDIRECT)
-                                .header("Location", "/api/v1/reservation/" + scheduleId)
-                                .body(status);
-                    }
-                    return ResponseEntity.ok(status);
-                });
+                .map(ResponseEntity::ok);
     }
 
     /**

--- a/src/main/java/com/fairticket/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/fairticket/domain/reservation/controller/ReservationController.java
@@ -1,6 +1,7 @@
 package com.fairticket.domain.reservation.controller;
 
 import com.fairticket.domain.reservation.dto.CancellationWindowResponse;
+import com.fairticket.domain.reservation.dto.MyReservationResponse;
 import com.fairticket.domain.reservation.dto.ReservationResponse;
 import com.fairticket.domain.reservation.service.CancellationWindowService;
 import com.fairticket.domain.reservation.service.ReservationCancelService;
@@ -16,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 @Tag(name = "Reservation", description = "예약 조회/취소 API")
 @RestController
@@ -46,6 +49,15 @@ public class ReservationController {
             @Parameter(description = "공연 일정 ID", required = true)
             @RequestParam Long scheduleId) {
         return reservationService.getPendingReservation(userId, scheduleId)
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "내 예매 내역 조회", description = "마이페이지용. 트랙 타입, 좌석 배정 정보 포함.")
+    @GetMapping("/my")
+    public Mono<ResponseEntity<List<MyReservationResponse>>> getMyReservations(
+            @RequestHeader("X-User-Id") Long userId) {
+        return reservationService.getMyReservations(userId)
+                .collectList()
                 .map(ResponseEntity::ok);
     }
 

--- a/src/main/java/com/fairticket/domain/reservation/dto/MyReservationResponse.java
+++ b/src/main/java/com/fairticket/domain/reservation/dto/MyReservationResponse.java
@@ -1,0 +1,51 @@
+package com.fairticket.domain.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "마이페이지 예매 내역 응답")
+public class MyReservationResponse {
+
+    @Schema(description = "예약 ID")
+    private Long id;
+
+    @Schema(description = "공연 일정 ID")
+    private Long scheduleId;
+
+    @Schema(description = "좌석 등급")
+    private String grade;
+
+    @Schema(description = "예약 수량")
+    private Integer quantity;
+
+    @Schema(description = "트랙 타입 (LOTTERY/LIVE)")
+    private String trackType;
+
+    @Schema(description = "예약 상태")
+    private String status;
+
+    @Schema(description = "배정된 좌석 목록")
+    private List<SeatInfo> seats;
+
+    @Schema(description = "예약 생성 시각")
+    private LocalDateTime createdAt;
+
+    @Getter
+    @Builder
+    public static class SeatInfo {
+        @Schema(description = "구역")
+        private String zone;
+
+        @Schema(description = "좌석 번호")
+        private String seatNumber;
+
+        @Schema(description = "좌석 상태 (PENDING/ASSIGNED/CANCELLED)")
+        private String status;
+    }
+}

--- a/src/main/java/com/fairticket/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/fairticket/domain/reservation/repository/ReservationRepository.java
@@ -55,4 +55,10 @@ public interface ReservationRepository extends ReactiveCrudRepository<Reservatio
 
     // 사용자의 해당 공연 일정의 PENDING 상태 예약 조회 (결제 대기 중인 예약 재조회용)
     Mono<Reservation> findFirstByUserIdAndScheduleIdAndStatusOrderByCreatedAtDesc(Long userId, Long scheduleId, String status);
+
+    // 추첨 결제 확정(PAID_PENDING_SEAT) 수량 합계 (라이브 좌석 보호용: 풀 잔여 - 이 값 = 라이브 판매 가능량)
+    @Query("SELECT COALESCE(SUM(quantity), 0) FROM reservations " +
+           "WHERE schedule_id = :scheduleId AND grade = :grade AND track_type = 'LOTTERY' " +
+           "AND status = 'PAID_PENDING_SEAT'")
+    Mono<Long> sumLotteryPaidQuantityByScheduleAndGrade(Long scheduleId, String grade);
 }

--- a/src/main/java/com/fairticket/domain/reservation/service/LiveHoldExpiryScheduler.java
+++ b/src/main/java/com/fairticket/domain/reservation/service/LiveHoldExpiryScheduler.java
@@ -11,15 +11,18 @@ import com.fairticket.domain.seat.service.SeatHoldService;
 import com.fairticket.domain.seat.service.SeatPoolService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
 // 라이브 트랙 좌석 홀드 만료 처리: 좌석 선택 후 최대 HOLD_MINUTES(10분) 경과 시 좌석 반환
-// 결제 완료 시에는 LiveTrackService.releaseHoldsForReservation으로 즉시 홀드 해제
+// 결제 완료 시에는 LiveTrackService.onPaymentCompleted로 즉시 홀드 해제 + 상태 전이
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -29,27 +32,39 @@ public class LiveHoldExpiryScheduler {
     private final ReservationRepository reservationRepository;
     private final SeatHoldService seatHoldService;
     private final SeatPoolService seatPoolService;
+    private final RedissonClient redissonClient;
 
     @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
     public void releaseExpiredHolds() {
-        LocalDateTime expiryThreshold = LocalDateTime.now().minusMinutes(ReservationConstants.HOLD_MINUTES);
-        reservationSeatRepository.findByStatusAndCreatedAtBefore(
-                        ReservationSeatStatus.PENDING.name(), expiryThreshold)
-                .flatMap(rs -> reservationRepository.findById(rs.getReservationId())
-                        .filter(r -> "LIVE".equals(r.getTrackType()))
-                        .flatMap(reservation -> releaseOne(reservation, rs)))
-                .doOnSubscribe(s -> log.debug("라이브 홀드 만료 스캔 시작"))
-                .count()
-                .doOnSuccess(count -> {
-                    if (count > 0) {
-                        log.info("라이브 홀드 만료 처리: {}건 좌석 풀 반환", count);
-                    }
-                })
-                .onErrorResume(e -> {
-                    log.warn("라이브 홀드 만료 스케줄러 오류: {}", e.getMessage());
-                    return Mono.just(0L);
-                })
-                .subscribe();
+        RLock lock = redissonClient.getLock("scheduler:live-hold-expiry");
+        boolean acquired = false;
+        try {
+            acquired = lock.tryLock(0, 55, TimeUnit.SECONDS);
+            if (!acquired) return;
+
+            LocalDateTime expiryThreshold = LocalDateTime.now().minusMinutes(ReservationConstants.HOLD_MINUTES);
+            reservationSeatRepository.findByStatusAndCreatedAtBefore(
+                            ReservationSeatStatus.PENDING.name(), expiryThreshold)
+                    .flatMap(rs -> reservationRepository.findById(rs.getReservationId())
+                            .filter(r -> "LIVE".equals(r.getTrackType()))
+                            .flatMap(reservation -> releaseOne(reservation, rs)))
+                    .count()
+                    .doOnSuccess(count -> {
+                        if (count > 0) {
+                            log.info("라이브 홀드 만료 처리: {}건 좌석 풀 반환", count);
+                        }
+                    })
+                    .block(Duration.ofSeconds(30));
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.error("라이브 홀드 만료 스케줄러 오류", e);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 
     private Mono<Long> releaseOne(Reservation reservation, ReservationSeat seat) {

--- a/src/main/java/com/fairticket/domain/reservation/service/LiveTrackCloseScheduler.java
+++ b/src/main/java/com/fairticket/domain/reservation/service/LiveTrackCloseScheduler.java
@@ -1,9 +1,12 @@
 package com.fairticket.domain.reservation.service;
 
+import com.fairticket.domain.concert.entity.ScheduleStatus;
 import com.fairticket.domain.concert.repository.ScheduleRepository;
 import com.fairticket.global.util.RedisKeyGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -16,122 +19,170 @@ import java.util.concurrent.TimeUnit;
 // 라이브 트랙 마감 조건:
 // 1. 라이브 시작(티켓 오픈) 1시간 경과 시 마감
 // 2. (보조) 대기열 0인 상태가 10분 이상 지속 시 마감. 단, 오픈 후 30분이 지난 뒤에만 적용
-// 추첨 좌석 배정은 라이브 트랙 시작(티켓 오픈) LOTTERY_ASSIGNMENT_DELAY_MINUTES_AFTER_OPEN분 후로 고정되어 실행된다.   
-// 배정 완료 시 사용자에게 알림을 보낸다 (TODO(알림): 알림 담당자 구현)
+// 추첨 좌석 배정은 라이브 트랙 시작(티켓 오픈) 후 고정 시점에 실행된다.
+// 라이브 마감 + 추첨 배정 모두 완료되면 Schedule.status → COMPLETED로 전이하여 이후 스캔에서 제외.
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class LiveTrackCloseScheduler {
 
-    // 라이브 트랙 시작(티켓 오픈) 후 이 시간(분)이 지나면 마감
     private static final int LIVE_TRACK_DURATION_MINUTES = 60;
-    // 대기열 0인 상태가 이 시간(분) 이상 지속되면 마감 (보조 조건)
     private static final int QUEUE_ZERO_DURATION_MINUTES = 10;
-    // 이 시간(분) 미만이면 오픈 직후로 간주하여, 대기열 0 지속만으로는 마감하지 않음
     private static final int MIN_OPEN_DURATION_MINUTES = 30;
-    // 추첨 좌석 배정 실행 시점: 라이브 트랙 시작(티켓 오픈) 후 이 시간(분) 경과 시
     private static final int LOTTERY_ASSIGNMENT_DELAY_MINUTES_AFTER_OPEN = 60;
 
     private final ScheduleRepository scheduleRepository;
     private final ReactiveRedisTemplate<String, String> redisTemplate;
     private final LotteryTrackService lotteryTrackService;
+    private final RedissonClient redissonClient;
 
     @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
     public void checkAndCloseLiveTrackByQueueEmpty() {
-        LocalDateTime now = LocalDateTime.now();
-        // 티켓 오픈이 이미 지난 회차만 조회
-        scheduleRepository.findByTicketOpenAtLessThanEqual(now)
-                .flatMap(schedule -> {
-                    Long scheduleId = schedule.getId();
-                    String queueKey = RedisKeyGenerator.queueKey(scheduleId);
-                    String zeroSinceKey = RedisKeyGenerator.queueZeroSinceKey(scheduleId);
-                    String closedKey = RedisKeyGenerator.liveClosedKey(scheduleId);
-                    long openDurationMin = Duration.between(schedule.getTicketOpenAt(), now).toMinutes();
+        RLock lock = redissonClient.getLock("scheduler:live-track-close");
+        boolean acquired = false;
+        try {
+            acquired = lock.tryLock(0, 55, TimeUnit.SECONDS);
+            if (!acquired) return;
 
-                    // 1) 라이브 시작 1시간 경과 시 마감
-                    if (openDurationMin >= LIVE_TRACK_DURATION_MINUTES) {
-                        return redisTemplate.hasKey(closedKey)
-                                .flatMap(alreadyClosed -> Boolean.TRUE.equals(alreadyClosed)
-                                        ? Mono.just(scheduleId)
-                                        : closeLiveTrackAndAssignLotteryIfNeeded(scheduleId, closedKey, zeroSinceKey)
+            LocalDateTime now = LocalDateTime.now();
+            scheduleRepository.findByTicketOpenAtLessThanEqualAndStatusNot(
+                            now, ScheduleStatus.COMPLETED.name())
+                    .flatMap(schedule -> {
+                        Long scheduleId = schedule.getId();
+                        String queueKey = RedisKeyGenerator.queueKey(scheduleId);
+                        String zeroSinceKey = RedisKeyGenerator.queueZeroSinceKey(scheduleId);
+                        String closedKey = RedisKeyGenerator.liveClosedKey(scheduleId);
+                        long openDurationMin = Duration.between(schedule.getTicketOpenAt(), now).toMinutes();
+
+                        if (openDurationMin >= LIVE_TRACK_DURATION_MINUTES) {
+                            return redisTemplate.hasKey(closedKey)
+                                    .flatMap(alreadyClosed -> {
+                                        if (Boolean.TRUE.equals(alreadyClosed)) {
+                                            // 이미 마감됨 — lottery 배정도 완료됐으면 COMPLETED 전이
+                                            return markScheduleCompleted(scheduleId).thenReturn(scheduleId);
+                                        }
+                                        return closeLiveTrack(scheduleId, closedKey, zeroSinceKey)
+                                                .then(updateScheduleStatus(scheduleId, ScheduleStatus.CLOSED))
+                                                .then(markScheduleCompleted(scheduleId))
                                                 .doOnSuccess(v -> log.info("라이브 트랙 마감(시작 1시간 경과): scheduleId={}", scheduleId))
-                                                .thenReturn(scheduleId));
-                    }
+                                                .thenReturn(scheduleId);
+                                    });
+                        }
 
-                    return redisTemplate.opsForZSet().size(queueKey)
-                            .flatMap(queueSize -> {
-                                if (queueSize != null && queueSize > 0) {
-                                    return redisTemplate.delete(zeroSinceKey).thenReturn(scheduleId);
-                                }
-                                return redisTemplate.opsForValue().get(zeroSinceKey)
-                                        .switchIfEmpty(Mono.defer(() -> {
-                                            long nowMs = System.currentTimeMillis();
-                                            return redisTemplate.opsForValue().set(zeroSinceKey, String.valueOf(nowMs))
-                                                    .thenReturn(String.valueOf(nowMs));
-                                        }))
-                                        .flatMap(tsStr -> {
-                                            long zeroSince = Long.parseLong(tsStr);
-                                            long elapsedMin = (System.currentTimeMillis() - zeroSince) / (60 * 1000);
-                                            boolean canCloseByQueueEmpty = elapsedMin >= QUEUE_ZERO_DURATION_MINUTES
-                                                    && openDurationMin >= MIN_OPEN_DURATION_MINUTES;
-                                            if (canCloseByQueueEmpty) {
-                                                return closeLiveTrackAndAssignLotteryIfNeeded(scheduleId, closedKey, zeroSinceKey)
-                                                        .doOnSuccess(v -> log.info("라이브 트랙 마감(대기열 0 지속 {}분): scheduleId={}", QUEUE_ZERO_DURATION_MINUTES, scheduleId))
-                                                        .thenReturn(scheduleId);
-                                            }
-                                            return Mono.just(scheduleId);
-                                        })
-                                        .switchIfEmpty(Mono.just(scheduleId));
+                        return redisTemplate.opsForZSet().size(queueKey)
+                                .flatMap(queueSize -> {
+                                    if (queueSize != null && queueSize > 0) {
+                                        return redisTemplate.delete(zeroSinceKey).thenReturn(scheduleId);
+                                    }
+                                    return redisTemplate.opsForValue().get(zeroSinceKey)
+                                            .switchIfEmpty(Mono.defer(() -> {
+                                                long nowMs = System.currentTimeMillis();
+                                                return redisTemplate.opsForValue().set(zeroSinceKey, String.valueOf(nowMs))
+                                                        .thenReturn(String.valueOf(nowMs));
+                                            }))
+                                            .flatMap(tsStr -> {
+                                                long zeroSince = Long.parseLong(tsStr);
+                                                long elapsedMin = (System.currentTimeMillis() - zeroSince) / (60 * 1000);
+                                                boolean canClose = elapsedMin >= QUEUE_ZERO_DURATION_MINUTES
+                                                        && openDurationMin >= MIN_OPEN_DURATION_MINUTES;
+                                                if (canClose) {
+                                                    return closeLiveTrack(scheduleId, closedKey, zeroSinceKey)
+                                                            .then(updateScheduleStatus(scheduleId, ScheduleStatus.CLOSED))
+                                                            .doOnSuccess(v -> log.info("라이브 트랙 마감(대기열 0 지속 {}분): scheduleId={}", QUEUE_ZERO_DURATION_MINUTES, scheduleId))
+                                                            .thenReturn(scheduleId);
+                                                }
+                                                return Mono.just(scheduleId);
+                                            })
+                                            .switchIfEmpty(Mono.just(scheduleId));
                                 });
-                })
-                .doOnSubscribe(s -> log.debug("라이브 트랙 대기열 0 마감 체크 시작"))
-                .onErrorResume(e -> {
-                    log.warn("라이브 트랙 마감 스케줄러 오류: {}", e.getMessage());
-                    return Mono.empty();
-                })
-                .subscribe();
+                    })
+                    .collectList()
+                    .block(Duration.ofSeconds(30));
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.error("라이브 트랙 마감 스케줄러 오류", e);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 
-    // 추첨 좌석 배정: 라이브 트랙 시작(티켓 오픈) LOTTERY_ASSIGNMENT_DELAY_MINUTES_AFTER_OPEN분 후로 고정.
-    // 1분마다 스캔하여, 오픈 후 1시간이 지났고 아직 배정되지 않은 회차에 대해 배정 실행 및 알림 호출.
     @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
     public void assignLotterySeatsAtFixedTimeAfterOpen() {
-        LocalDateTime now = LocalDateTime.now();
-        // 티켓 오픈 후 60분이 지난 회차만 조회 (추첨 좌석 배정 시점)
-        LocalDateTime threshold = now.minusMinutes(LOTTERY_ASSIGNMENT_DELAY_MINUTES_AFTER_OPEN);
-        scheduleRepository.findByTicketOpenAtLessThanEqual(threshold)
-                .flatMap(schedule -> {
-                    Long scheduleId = schedule.getId();
-                    String lotteryAssignedKey = RedisKeyGenerator.lotteryAssignedKey(scheduleId);
-                    return redisTemplate.hasKey(lotteryAssignedKey)
-                            .filter(assigned -> Boolean.FALSE.equals(assigned))
-                            .flatMap(ignored -> lotteryTrackService.assignSeatsToPaidLotteryAndMerge(scheduleId)
-                                    .then(redisTemplate.opsForValue().set(lotteryAssignedKey, "1", Duration.ofDays(1)))
-                                    .then(notifyLotterySeatAssignmentComplete(scheduleId))
-                                    .doOnSuccess(v -> log.info("추첨 좌석 배정 실행 완료(오픈 {}분 후): scheduleId={}", LOTTERY_ASSIGNMENT_DELAY_MINUTES_AFTER_OPEN, scheduleId)));
-                })
-                .doOnSubscribe(s -> log.debug("추첨 좌석 배정 스캔 시작"))
-                .onErrorResume(e -> {
-                    log.warn("추첨 좌석 배정 스케줄러 오류: {}", e.getMessage());
-                    return Mono.empty();
-                })
-                .subscribe();
+        RLock lock = redissonClient.getLock("scheduler:lottery-assignment");
+        boolean acquired = false;
+        try {
+            acquired = lock.tryLock(0, 55, TimeUnit.SECONDS);
+            if (!acquired) return;
+
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime threshold = now.minusMinutes(LOTTERY_ASSIGNMENT_DELAY_MINUTES_AFTER_OPEN);
+            scheduleRepository.findByTicketOpenAtLessThanEqualAndStatusNot(
+                            threshold, ScheduleStatus.COMPLETED.name())
+                    .flatMap(schedule -> {
+                        Long scheduleId = schedule.getId();
+                        String lotteryAssignedKey = RedisKeyGenerator.lotteryAssignedKey(scheduleId);
+                        return redisTemplate.hasKey(lotteryAssignedKey)
+                                .filter(assigned -> Boolean.FALSE.equals(assigned))
+                                .flatMap(ignored -> lotteryTrackService.assignSeatsToPaidLotteryAndMerge(scheduleId)
+                                        .then(redisTemplate.opsForValue().set(lotteryAssignedKey, "1", Duration.ofDays(1)))
+                                        .then(markScheduleCompleted(scheduleId))
+                                        .doOnSuccess(v -> log.info("추첨 좌석 배정 완료 + Schedule COMPLETED: scheduleId={}", scheduleId)));
+                    })
+                    .collectList()
+                    .block(Duration.ofSeconds(30));
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.error("추첨 좌석 배정 스케줄러 오류", e);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 
-    // 라이브 마감 플래그 설정 및 대기열 0 타이머 초기화.
-    // 추첨 좌석 배정은 별도 스케줄러(오픈 1시간 후 고정)에서 수행한다.
-    private Mono<Void> closeLiveTrackAndAssignLotteryIfNeeded(Long scheduleId, String closedKey, String zeroSinceKey) {
+    private Mono<Void> closeLiveTrack(Long scheduleId, String closedKey, String zeroSinceKey) {
         long closedAtMs = System.currentTimeMillis();
         return redisTemplate.opsForValue().set(closedKey, String.valueOf(closedAtMs), Duration.ofDays(2))
                 .then(zeroSinceKey != null ? redisTemplate.delete(zeroSinceKey) : Mono.empty())
                 .then();
     }
 
-    // 추첨 좌석 배정이 완료되었을 때 해당 회차 당첨 사용자에게 알림을 보낸다.
-    // TODO(알림): 푸시/이메일/SMS 등 - 당첨자 목록 조회 후 발송. 알림 담당자 구현.
-    private Mono<Void> notifyLotterySeatAssignmentComplete(Long scheduleId) {
-        // TODO(알림): 해당 scheduleId의 추첨 결제 완료자 목록 조회 후 알림 발송
-        log.info("추첨 좌석 배정 완료 알림 대상: scheduleId={}", scheduleId);
-        return Mono.empty();
+    private Mono<Void> updateScheduleStatus(Long scheduleId, ScheduleStatus status) {
+        return scheduleRepository.findById(scheduleId)
+                .flatMap(schedule -> {
+                    schedule.setStatus(status.name());
+                    return scheduleRepository.save(schedule);
+                })
+                .then();
+    }
+
+    // 라이브 마감 + 추첨 배정 모두 완료 시 COMPLETED로 전이. 이후 스케줄러 스캔에서 제외됨.
+    private Mono<Void> markScheduleCompleted(Long scheduleId) {
+        return Mono.zip(
+                redisTemplate.hasKey(RedisKeyGenerator.liveClosedKey(scheduleId)),
+                redisTemplate.hasKey(RedisKeyGenerator.lotteryAssignedKey(scheduleId))
+        ).flatMap(tuple -> {
+            boolean liveClosed = Boolean.TRUE.equals(tuple.getT1());
+            boolean lotteryAssigned = Boolean.TRUE.equals(tuple.getT2());
+            if (liveClosed && lotteryAssigned) {
+                return updateScheduleStatus(scheduleId, ScheduleStatus.COMPLETED)
+                        .then(cleanupRedisKeys(scheduleId));
+            }
+            return Mono.empty();
+        });
+    }
+
+    // COMPLETED 전이 시 관련 Redis 키 정리 (TTL 의존 제거)
+    private Mono<Void> cleanupRedisKeys(Long scheduleId) {
+        return redisTemplate.delete(RedisKeyGenerator.liveClosedKey(scheduleId))
+                .then(redisTemplate.delete(RedisKeyGenerator.lotteryAssignedKey(scheduleId)))
+                .then(redisTemplate.delete(RedisKeyGenerator.queueZeroSinceKey(scheduleId)))
+                .then();
     }
 }

--- a/src/main/java/com/fairticket/domain/reservation/service/LiveTrackService.java
+++ b/src/main/java/com/fairticket/domain/reservation/service/LiveTrackService.java
@@ -11,6 +11,7 @@ import com.fairticket.domain.reservation.repository.ReservationSeatRepository;
 import com.fairticket.domain.reservation.constants.ReservationConstants;
 import com.fairticket.domain.seat.dto.SeatSelectionRequest;
 import com.fairticket.domain.seat.dto.SeatSelectionResponse;
+import com.fairticket.domain.seat.entity.SeatStatus;
 import com.fairticket.domain.seat.repository.SeatRepository;
 import com.fairticket.domain.seat.service.SeatHoldService;
 import com.fairticket.domain.seat.service.SeatPoolService;
@@ -67,6 +68,12 @@ public class LiveTrackService {
                         reservationRepository.sumLiveQuantityByUserAndSchedule(scheduleId, userId)
                                 .map(qty -> (qty != null ? qty : 0L) < ReservationConstants.LIVE_MAX_QUANTITY_PER_USER),
                         ErrorCode.LIVE_MAX_QUANTITY_EXCEEDED))
+                // 4-1. 추첨 결제 확정분 보호: 등급별 잔여석에서 추첨 결제 확정 수량을 뺀 만큼만 라이브 판매 가능
+                .then(requireTrue(
+                        seatPoolService.getRemainingSeatsForGrade(scheduleId, request.getGrade())
+                                .zipWith(reservationRepository.sumLotteryPaidQuantityByScheduleAndGrade(scheduleId, request.getGrade()))
+                                .map(tuple -> tuple.getT1() - tuple.getT2() > 0),
+                        ErrorCode.SOLD_OUT))
                 // 5. 등급·구역 검증: 선택한 구역이 해당 등급에 속하는지
                 .then(scheduleService.validateGradeAndZone(scheduleId, request.getGrade(), request.getZone()))
                 // 6. 좌석 풀에서 제거 후 7. 홀드 설정 (홀드 실패 시 풀에 좌석 반환)
@@ -142,16 +149,35 @@ public class LiveTrackService {
                 .then();
     }
 
-    // 라이브 예약 결제 완료 시 해당 예약의 좌석 홀드를 즉시 해제.
-    // PaymentService(또는 결제 콜백)에서 라이브 결제 완료 처리 후 반드시 호출할 것.
-    public Mono<Void> releaseHoldsForReservation(Long reservationId) {
+    // 라이브 결제 완료 시 후속 처리:
+    // 1) Redis 홀드 해제 (LiveHoldExpiryScheduler가 만료 처리하지 않도록)
+    // 2) ReservationSeat PENDING → ASSIGNED
+    // 3) Seat.status → SOLD
+    // 4) Reservation PENDING → PAID
+    public Mono<Void> onPaymentCompleted(Long reservationId) {
         return reservationRepository.findById(reservationId)
                 .filter(r -> TrackType.LIVE.name().equals(r.getTrackType()))
-                .flatMapMany(reservation -> reservationSeatRepository.findByReservationId(reservationId)
-                        .flatMap(seat -> seatHoldService.releaseHold(reservation.getScheduleId(), seat.getZone(), seat.getSeatNumber())
-                                .thenReturn(seat)))
-                .then()
-                .doOnSuccess(v -> log.info("라이브 결제 완료로 홀드 해제: reservationId={}", reservationId));
+                .flatMap(reservation -> {
+                    Long scheduleId = reservation.getScheduleId();
+                    return reservationSeatRepository.findByReservationId(reservationId)
+                            .filter(rs -> ReservationSeatStatus.PENDING.name().equals(rs.getStatus()))
+                            .flatMap(seat ->
+                                    seatHoldService.releaseHold(scheduleId, seat.getZone(), seat.getSeatNumber())
+                                            .then(seatRepository.updateStatusByScheduleIdAndZoneAndSeatNumber(
+                                                    SeatStatus.SOLD.name(), scheduleId, seat.getZone(), seat.getSeatNumber()))
+                                            .then(Mono.defer(() -> {
+                                                seat.setStatus(ReservationSeatStatus.ASSIGNED.name());
+                                                seat.setAssignedAt(LocalDateTime.now());
+                                                return reservationSeatRepository.save(seat);
+                                            })))
+                            .then(Mono.defer(() -> {
+                                reservation.setStatus(ReservationStatus.PAID.name());
+                                reservation.setUpdatedAt(LocalDateTime.now());
+                                return reservationRepository.save(reservation);
+                            }));
+                })
+                .doOnSuccess(v -> log.info("라이브 결제 완료 처리: reservationId={}", reservationId))
+                .then();
     }
 
     // 선택한 등급에 속한 구역 목록 (등급 선택 후 구역 선택용)

--- a/src/main/java/com/fairticket/domain/reservation/service/LotteryPaymentExpiryScheduler.java
+++ b/src/main/java/com/fairticket/domain/reservation/service/LotteryPaymentExpiryScheduler.java
@@ -1,5 +1,6 @@
 package com.fairticket.domain.reservation.service;
 
+import com.fairticket.domain.concert.entity.ScheduleStatus;
 import com.fairticket.domain.concert.repository.ScheduleRepository;
 import com.fairticket.domain.reservation.constants.ReservationConstants;
 import com.fairticket.domain.reservation.entity.ReservationStatus;
@@ -7,14 +8,17 @@ import com.fairticket.domain.reservation.entity.TrackType;
 import com.fairticket.domain.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
-// 추첨 결제 마감(티켓 오픈 15분 전) 경과 시, 미결제(PENDING) 추첨 예약을 자동 취소한다
+// 추첨 결제 마감(티켓 오픈 LOTTERY_PAYMENT_CLOSE_MINUTES분 전) 경과 시,
+// 미결제(PENDING) 추첨 예약을 자동 취소한다.
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -22,28 +26,50 @@ public class LotteryPaymentExpiryScheduler {
 
     private final ScheduleRepository scheduleRepository;
     private final ReservationRepository reservationRepository;
+    private final RedissonClient redissonClient;
 
     @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
     public void cancelUnpaidLotteryReservations() {
-        LocalDateTime now = LocalDateTime.now();
-        // 추첨 결제 마감(티켓 오픈 15분 전)이 지난 회차만 조회
-        LocalDateTime threshold = now.plusMinutes(ReservationConstants.LOTTERY_PAYMENT_CLOSE_MINUTES);
-        scheduleRepository.findByTicketOpenAtLessThanEqual(threshold)
-                .flatMap(schedule -> reservationRepository
-                        .findByScheduleIdAndTrackTypeAndStatus(
-                                schedule.getId(), TrackType.LOTTERY.name(), ReservationStatus.PENDING.name())
-                        .flatMap(reservation -> {
-                            reservation.setStatus(ReservationStatus.CANCELLED.name());
-                            reservation.setUpdatedAt(now);
-                            return reservationRepository.save(reservation)
-                                    .doOnSuccess(r -> log.info("추첨 미결제 자동 취소: reservationId={}, scheduleId={}, userId={}",
-                                            r.getId(), r.getScheduleId(), r.getUserId()));
-                        }))
-                .doOnSubscribe(s -> log.debug("추첨 결제 마감 스캔 시작"))
-                .onErrorResume(e -> {
-                    log.warn("추첨 결제 마감 스케줄러 오류: {}", e.getMessage());
-                    return Mono.empty();
-                })
-                .subscribe();
+        RLock lock = redissonClient.getLock("scheduler:lottery-payment-expiry");
+        boolean acquired = false;
+        try {
+            acquired = lock.tryLock(0, 55, TimeUnit.SECONDS);
+            if (!acquired) return;
+
+            LocalDateTime now = LocalDateTime.now();
+            // 추첨 결제 마감 = ticketOpenAt - LOTTERY_PAYMENT_CLOSE_MINUTES
+            // 마감이 지난 회차: ticketOpenAt - 15분 <= now → ticketOpenAt <= now + 15분
+            // 단, COMPLETED 제외
+            LocalDateTime threshold = now.plusMinutes(ReservationConstants.LOTTERY_PAYMENT_CLOSE_MINUTES);
+            scheduleRepository.findByTicketOpenAtLessThanEqualAndStatusNot(
+                            threshold, ScheduleStatus.COMPLETED.name())
+                    .filter(schedule -> {
+                        // ticketOpenAt - 15분이 현재 시각 이전인 회차만 (결제 마감 시각이 지난 회차)
+                        LocalDateTime paymentCloseAt = schedule.getTicketOpenAt()
+                                .minusMinutes(ReservationConstants.LOTTERY_PAYMENT_CLOSE_MINUTES);
+                        return !now.isBefore(paymentCloseAt);
+                    })
+                    .flatMap(schedule -> reservationRepository
+                            .findByScheduleIdAndTrackTypeAndStatus(
+                                    schedule.getId(), TrackType.LOTTERY.name(), ReservationStatus.PENDING.name())
+                            .flatMap(reservation -> {
+                                reservation.setStatus(ReservationStatus.CANCELLED.name());
+                                reservation.setUpdatedAt(now);
+                                return reservationRepository.save(reservation)
+                                        .doOnSuccess(r -> log.info("추첨 미결제 자동 취소: reservationId={}, scheduleId={}, userId={}",
+                                                r.getId(), r.getScheduleId(), r.getUserId()));
+                            }))
+                    .collectList()
+                    .block(Duration.ofSeconds(30));
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.error("추첨 결제 마감 스케줄러 오류", e);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 }

--- a/src/main/java/com/fairticket/domain/reservation/service/LotteryTrackService.java
+++ b/src/main/java/com/fairticket/domain/reservation/service/LotteryTrackService.java
@@ -313,7 +313,7 @@ public class LotteryTrackService {
     // 모든 등급이 등급별 절반 할당에 도달했을 때만 true. 등급별 집계 쿼리 2회로 조회.
     public Mono<Boolean> hasLotteryQuotaReached(Long scheduleId) {
         Mono<Map<String, Long>> seatCountsMono = seatRepository.findSeatCountByScheduleIdGroupByGrade(scheduleId)
-                .collectMap(GradeSeatCount::getGrade, GradeSeatCount::getCount);
+                .collectMap(GradeSeatCount::getGrade, g -> g.getCount() != null ? g.getCount() : 0L);
         Mono<Map<String, Long>> reservedMono = reservationRepository.findLotteryReservedSumByScheduleIdGroupByGrade(scheduleId)
                 .collectMap(GradeReservedSum::getGrade, GradeReservedSum::getTotal);
         Mono<List<String>> gradesMono = gradeRepository.findByScheduleId(scheduleId)

--- a/src/main/java/com/fairticket/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/fairticket/domain/reservation/service/ReservationService.java
@@ -1,14 +1,17 @@
 package com.fairticket.domain.reservation.service;
 
+import com.fairticket.domain.reservation.dto.MyReservationResponse;
 import com.fairticket.domain.reservation.dto.ReservationResponse;
 import com.fairticket.domain.reservation.entity.Reservation;
 import com.fairticket.domain.reservation.entity.ReservationStatus;
 import com.fairticket.domain.reservation.repository.ReservationRepository;
+import com.fairticket.domain.reservation.repository.ReservationSeatRepository;
 import com.fairticket.global.exception.BusinessException;
 import com.fairticket.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
@@ -19,6 +22,7 @@ import java.time.LocalDateTime;
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
+    private final ReservationSeatRepository reservationSeatRepository;
 
     /**
      * 사용자의 해당 공연 일정에서 결제 대기 중인(PENDING) 예약을 조회합니다.
@@ -40,12 +44,34 @@ public class ReservationService {
                         userId, scheduleId, error.getMessage()));
     }
 
+    // 마이페이지: 내 전체 예매 내역 (트랙 타입, 좌석 배정 정보 포함)
+    public Flux<MyReservationResponse> getMyReservations(Long userId) {
+        return reservationRepository.findByUserId(userId)
+                .flatMap(reservation -> reservationSeatRepository.findByReservationId(reservation.getId())
+                        .map(rs -> MyReservationResponse.SeatInfo.builder()
+                                .zone(rs.getZone())
+                                .seatNumber(rs.getSeatNumber())
+                                .status(rs.getStatus())
+                                .build())
+                        .collectList()
+                        .map(seats -> MyReservationResponse.builder()
+                                .id(reservation.getId())
+                                .scheduleId(reservation.getScheduleId())
+                                .grade(reservation.getGrade())
+                                .quantity(reservation.getQuantity())
+                                .trackType(reservation.getTrackType())
+                                .status(reservation.getStatus())
+                                .seats(seats)
+                                .createdAt(reservation.getCreatedAt())
+                                .build()));
+    }
+
     /**
      * Reservation 엔티티를 ReservationResponse DTO로 변환합니다.
      */
     private ReservationResponse toReservationResponse(Reservation reservation) {
         // 결제 만료 시간: 예약 생성 후 5분 (Payment 타이머 기준)
-        LocalDateTime paymentDeadline = reservation.getCreatedAt() != null ? 
+        LocalDateTime paymentDeadline = reservation.getCreatedAt() != null ?
                 reservation.getCreatedAt().plusMinutes(5) : null;
 
         return ReservationResponse.builder()

--- a/src/main/java/com/fairticket/domain/seat/dto/GradeSeatCount.java
+++ b/src/main/java/com/fairticket/domain/seat/dto/GradeSeatCount.java
@@ -3,5 +3,5 @@ package com.fairticket.domain.seat.dto;
 // 등급별 좌석 수 집계 결과 (GROUP BY grade 쿼리용)
 public interface GradeSeatCount {
     String getGrade();
-    long getCount();
+    Long getCount();
 }

--- a/src/main/java/com/fairticket/domain/seat/service/SeatPoolService.java
+++ b/src/main/java/com/fairticket/domain/seat/service/SeatPoolService.java
@@ -190,4 +190,12 @@ public class SeatPoolService {
                 .map(total -> total / 2)
                 .defaultIfEmpty(0L);
     }
+
+    // 등급별 Redis 풀 잔여 좌석 수 (라이브 판매 가능량 계산용)
+    public Mono<Long> getRemainingSeatsForGrade(Long scheduleId, String grade) {
+        return zoneRepository.findByScheduleIdAndGrade(scheduleId, grade)
+                .flatMap(zone -> redisTemplate.opsForSet()
+                        .size(RedisKeyGenerator.seatsKey(scheduleId, zone.getZone())))
+                .reduce(0L, Long::sum);
+    }
 }

--- a/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/fairticket/global/util/RedisKeyGenerator.java
@@ -1,96 +1,89 @@
-  package com.fairticket.global.util;                                           
-   
-  /**                                                                           
-   * Redis 키 생성을 위한 유틸리티 클래스                   
-   */
-  public class RedisKeyGenerator {
+package com.fairticket.global.util;
 
-      private RedisKeyGenerator() {
-          throw new UnsupportedOperationException("유틸리티 클래스는
-  인스턴스화할 수 없습니다.");
-      }
+/**
+ * Redis 키 생성을 위한 유틸리티 클래스
+ */
+public class RedisKeyGenerator {
 
-      // 대기열 순번 관리 키 (SortedSet) - queue:{scheduleId}
-      public static String queueKey(Long scheduleId) {
-          return String.format("queue:%d", scheduleId);
-      }
+    private RedisKeyGenerator() {
+        throw new UnsupportedOperationException("유틸리티 클래스는 인스턴스화할 수 없습니다.");
+    }
 
-      // 구역별 잔여 좌석 풀 키 (Set) - seats:{scheduleId}:{zone}
-      public static String seatsKey(Long scheduleId, String zone) {
-          return String.format("seats:%d:%s", scheduleId, zone);
-      }
+    // 대기열 순번 관리 키 (SortedSet) - queue:{scheduleId}
+    public static String queueKey(Long scheduleId) {
+        return String.format("queue:%d", scheduleId);
+    }
 
-      // 좌석 임시 홀드 키 (String+TTL, 660초) -
-  hold:{scheduleId}:{zone}:{seatNo}
-      public static String holdKey(Long scheduleId, String zone, String seatNo)
-  {
-          return String.format("hold:%d:%s:%s", scheduleId, zone, seatNo);
-      }
+    // 구역별 잔여 좌석 풀 키 (Set) - seats:{scheduleId}:{zone}
+    public static String seatsKey(Long scheduleId, String zone) {
+        return String.format("seats:%d:%s", scheduleId, zone);
+    }
 
-      // 입장 토큰 키 (Token+TTL, 300초) - token:%d:%d
-      public static String tokenKey(Long userId, Long scheduleId) {
-          return String.format("token:%d:%d", userId, scheduleId);
-      }
+    // 좌석 임시 홀드 키 (String+TTL, 660초) - hold:{scheduleId}:{zone}:{seatNo}
+    public static String holdKey(Long scheduleId, String zone, String seatNo) {
+        return String.format("hold:%d:%s:%s", scheduleId, zone, seatNo);
+    }
 
-      // 좌석 배정 분산 락 키 (Lock) - lock:assign:{scheduleId}:{grade}
-      public static String lockAssignKey(Long scheduleId, String grade) {
-          return String.format("lock:assign:%d:%s", scheduleId, grade);
-      }
+    // 입장 토큰 키 (Token+TTL, 300초) - token:%d:%d
+    public static String tokenKey(Long userId, Long scheduleId) {
+        return String.format("token:%d:%d", userId, scheduleId);
+    }
 
-      // 대기열 이탈 감지 키 (String+TTL, 30초) -
-  heartbeat:{scheduleId}:{userId}
-      public static String heartbeatKey(Long scheduleId, Long userId) {
-          return String.format("heartbeat:%d:%d", scheduleId, userId);
-      }
+    // 좌석 배정 분산 락 키 (Lock) - lock:assign:{scheduleId}:{grade}
+    public static String lockAssignKey(Long scheduleId, String grade) {
+        return String.format("lock:assign:%d:%s", scheduleId, grade);
+    }
 
-      // 동시 입장 인원 수 키 (String) - active:{scheduleId}
-      public static String activeKey(Long scheduleId) {
-          return String.format("active:%d", scheduleId);
-      }
+    // 대기열 이탈 감지 키 (String+TTL, 30초) - heartbeat:{scheduleId}:{userId}
+    public static String heartbeatKey(Long scheduleId, Long userId) {
+        return String.format("heartbeat:%d:%d", scheduleId, userId);
+    }
 
-      // 추첨 결제 성공자 목록 키 (Set) - lottery-paid:{scheduleId}
-      public static String lotteryPaidKey(Long scheduleId) {
-          return String.format("lottery-paid:%d", scheduleId);
-      }
+    // 동시 입장 인원 수 키 (String) - active:{scheduleId}
+    public static String activeKey(Long scheduleId) {
+        return String.format("active:%d", scheduleId);
+    }
 
-      // 미결제 자동 취소 타이머 키 (String+TTL) - payment-timer:{reservationId}
-      public static String paymentTimerKey(Long reservationId) {
-          return String.format("payment-timer:%d", reservationId);
-      }
+    // 추첨 결제 성공자 목록 키 (Set) - lottery-paid:{scheduleId}
+    public static String lotteryPaidKey(Long scheduleId) {
+        return String.format("lottery-paid:%d", scheduleId);
+    }
 
-      // 라이브 트랙 마감 시각 (값=epoch millis, 취소 가능 기간 계산용) -
-  live-closed:{scheduleId}
-      public static String liveClosedKey(Long scheduleId) {
-          return String.format("live-closed:%d", scheduleId);
-      }
+    // 미결제 자동 취소 타이머 키 (String+TTL) - payment-timer:{reservationId}
+    public static String paymentTimerKey(Long reservationId) {
+        return String.format("payment-timer:%d", reservationId);
+    }
 
-      // 대기열이 0이 된 시각 (0이 10분 지속 시 라이브 마감 판단용) -
-  queue-zero-since:{scheduleId}
-      public static String queueZeroSinceKey(Long scheduleId) {
-          return String.format("queue-zero-since:%d", scheduleId);
-      }
+    // 라이브 트랙 마감 시각 (값=epoch millis, 취소 가능 기간 계산용) - live-closed:{scheduleId}
+    public static String liveClosedKey(Long scheduleId) {
+        return String.format("live-closed:%d", scheduleId);
+    }
 
-      // 추첨 좌석 배정 완료 플래그 (라이브 마감 후 1회만 배정 실행) -
-  lottery-assigned:{scheduleId}
-      public static String lotteryAssignedKey(Long scheduleId) {
-          return String.format("lottery-assigned:%d", scheduleId);
-      }
+    // 대기열이 0이 된 시각 (0이 10분 지속 시 라이브 마감 판단용) - queue-zero-since:{scheduleId}
+    public static String queueZeroSinceKey(Long scheduleId) {
+        return String.format("queue-zero-since:%d", scheduleId);
+    }
 
-      // 활성 스케줄 목록 (KEYS 명령어 대체) - active-schedules
-      public static String activeSchedulesKey() {
-          return "active-schedules";
-      }
+    // 추첨 좌석 배정 완료 플래그 (라이브 마감 후 1회만 배정 실행) - lottery-assigned:{scheduleId}
+    public static String lotteryAssignedKey(Long scheduleId) {
+        return String.format("lottery-assigned:%d", scheduleId);
+    }
 
-      // JWT 블랙리스트 키 (로그아웃 시 토큰 무효화) - blacklist:{token}
-      public static String blacklistKey(String token) {
-          return "blacklist:" + token;
-      }
+    // 활성 스케줄 목록 (KEYS 명령어 대체) - active-schedules
+    public static String activeSchedulesKey() {
+        return "active-schedules";
+    }
 
-      // 등급별 잔여 재고 카운터 키 (String, atomic INCR/DECR 전용)
-      // - 결제 완료 시 DECR, 타임아웃/취소 시 INCR
-      // - SeatPool(Set)의 빠른 재고 확인용 캐시. 단일 출처는 seats 테이블.
-      // stock:{scheduleId}:{grade}
-      public static String stockKey(Long scheduleId, String grade) {
-          return String.format("stock:%d:%s", scheduleId, grade);
-      }
-  }
+    // JWT 블랙리스트 키 (로그아웃 시 토큰 무효화) - blacklist:{token}
+    public static String blacklistKey(String token) {
+        return "blacklist:" + token;
+    }
+
+    // 등급별 잔여 재고 카운터 키 (String, atomic INCR/DECR 전용)
+    // - 결제 완료 시 DECR, 타임아웃/취소 시 INCR
+    // - SeatPool(Set)의 빠른 재고 확인용 캐시. 단일 출처는 seats 테이블.
+    // stock:{scheduleId}:{grade}
+    public static String stockKey(Long scheduleId, String grade) {
+        return String.format("stock:%d:%s", scheduleId, grade);
+    }
+}


### PR DESCRIPTION
  ## Summary
  - LIVE 결제 완료 후속 처리: `PaymentService` → `LiveTrackService.onPaymentCompleted()` 연결 (홀드
  해제, Seat→SOLD, ReservationSeat→ASSIGNED, Reservation→PAID)
  - 미결제 만료 스케줄러(`PaymentExpiryScheduler`): impUid=null인 PENDING Payment 5분 후 자동 취소
  - Schedule lifecycle: `COMPLETED` 상태 추가, 스케줄러 쿼리에 `status != COMPLETED` 조건,
  `deriveSaleStatus`에서 COMPLETED=sold-out 처리
  - 전 스케줄러(6개) Redisson 분산 락 + `.block()` 전환, `markScheduleCompleted` 라이브 마감+추첨 배정
  양 조건 체크
  - FE↔BE 버그 수정: `WebhookRequest` `@JsonProperty` 추가, `QueueController` 307→200
  - 라이브 좌석 선택 시 추첨 결제 확정(PAID_PENDING_SEAT) 수량만큼 보호 — 라이브가 추첨 당첨자 좌석을
  침범하지 못하도록 차단
  - 마이페이지 내 예매 내역 API: `GET /api/v1/reservations/my` (트랙 타입, 좌석 배정 정보 포함)
  - `GradeSeatCount.getCount()` Long 변환 (NPE 방지)

  ## 변경 파일 (18개 수정 + 2개 신규)
  | 영역 | 파일 | 변경 |
  |---|---|---|
  | Schedule lifecycle | ScheduleStatus, ScheduleRepository, ConcertService | COMPLETED 상태 추가 +
  쿼리/상태 처리 |
  | 결제 | PaymentService, WebhookRequest | LIVE 후속처리 + @JsonProperty + 재고 카운터 통합 |
  | 스케줄러 | LiveTrackCloseScheduler, LiveHoldExpiryScheduler, LotteryPaymentExpiryScheduler,
  PaymentVerificationScheduler | 분산 락 + 종료 조건 |
  | 신규 스케줄러 | PaymentExpiryScheduler | 미결제 만료 처리 |
  | 추첨 보호 | LiveTrackService, SeatPoolService, ReservationRepository | 라이브 판매 시 추첨 확정분
  차감 체크 |
  | 마이페이지 | ReservationController, ReservationService, MyReservationResponse | 내 예매 내역 조회 |
  | 기타 | QueueController, GradeSeatCount, LotteryTrackService, RedisKeyGenerator | 버그 수정 +
  null-safe |

  ## Test plan
  - [ ] 회원가입 → 로그인 → 토큰 발급 정상 동작
  - [ ] 공연 목록/상세 조회 (COMPLETED 스케줄 sold-out 표시)
  - [ ] 추첨 예매 → 결제 → PAID_PENDING_SEAT 전이
  - [ ] 라이브 좌석 선택 → 결제 → PAID 전이 (홀드 해제 + SOLD)
  - [ ] 라이브에서 추첨 확정분 초과 시 SOLD_OUT 반환
  - [ ] 미결제 5분 경과 시 자동 취소 (PaymentExpiryScheduler)
  - [ ] 마이페이지 내 예매 내역 조회 (좌석 배정 정보 포함)
  - [ ] 스케줄러 분산 락 정상 동작 (중복 실행 방지)